### PR TITLE
 feat(gcs_enhancement): Enhancing Google Dataplane and Provisioner to…

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -60,6 +60,7 @@
         - [Blob](control-plane/provision/provision-blob/)
         - [HTTP](control-plane/provision/provision-http/)
         - [S3](control-plane/provision/provision-aws-s3/)
+        - [GCP](control-plane/provision/provision-gcs/)
     - Store
         - Cosmos
             - [Asset Index](control-plane/store/cosmos/asset-index-cosmos/)
@@ -81,6 +82,7 @@
     - [Data Factory](data-plane/data-plane-azure-data-factory/)
     - [HTTP](data-plane/data-plane-http/)
     - [S3](data-plane/data-plane-aws-s3/)
+    - [GCP](data-plane/data-plane-google-storage)
     - [Tests](data-plane/data-plane-integration-tests/)
 - Data Plane Selector
     - [API](data-plane-selector/data-plane-selector-api/)

--- a/extensions/common/gcp/gcp-core/build.gradle.kts
+++ b/extensions/common/gcp/gcp-core/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     implementation(libs.googlecloud.iam.admin)
     implementation(libs.googlecloud.storage)
     implementation(libs.googlecloud.iam.credentials)
+
+    testImplementation(project(":core:common:junit"))
 }
 
 publishing {

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpCredentials.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpCredentials.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.gcp.common;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+public class GcpCredentials {
+
+    public enum GcpCredentialType {
+        DEFAULT_APPLICATION, GOOGLE_ACCESS_TOKEN, GOOGLE_SERVICE_ACCOUNT_KEY_FILE
+    }
+
+    private final Base64.Decoder b64Decoder;
+    private final Vault vault;
+    private final TypeManager typeManager;
+    private final Monitor monitor;
+
+    public GcpCredentials(Vault vault, TypeManager typeManager, Monitor monitor) {
+        this.vault = vault;
+        this.typeManager = typeManager;
+        this.b64Decoder = Base64.getDecoder();
+        this.monitor = monitor;
+    }
+
+    /**
+     * Returns the Google Credentials which will be created based on the following order:
+     * if none of the  parameters were provided then Google Credentials will be retrieved from ApplicationDefaultCredentials
+     *    Otherwise it will be retrieved from a token or a Google Credentials file
+     *
+     * @param vaultTokenKeyName Key name of an entry in the vault containing an access token.
+     * @param vaultServiceAccountKeyName key name of an entry in the vault containing a valid Google Credentials file in json format.
+     * @param serviceAccountValue Content of a valid Google Credentials file in json format encoded with base64 .
+     *
+     * @return GoogleCredentials
+     */
+    public GoogleCredentials resolveGoogleCredentialsFromDataAddress(@Nullable String vaultTokenKeyName,
+                                                                     @Nullable String vaultServiceAccountKeyName,
+                                                                     @Nullable String serviceAccountValue) {
+        if (vaultTokenKeyName != null && !vaultTokenKeyName.isEmpty()) {
+            var tokenContent = vault.resolveSecret(vaultTokenKeyName);
+            return createGoogleCredential(tokenContent, GcpCredentialType.GOOGLE_ACCESS_TOKEN);
+        } else if (vaultServiceAccountKeyName != null && !vaultServiceAccountKeyName.isEmpty()) {
+            return createGoogleCredential(vault.resolveSecret(vaultServiceAccountKeyName), GcpCredentialType.GOOGLE_SERVICE_ACCOUNT_KEY_FILE);
+        } else if (serviceAccountValue != null && !serviceAccountValue.isEmpty()) {
+            try {
+                var serviceKeyContent = new String(b64Decoder.decode(serviceAccountValue));
+                if (!serviceKeyContent.contains("service_account")) {
+                    throw new GcpException("SERVICE_ACCOUNT_VALUE is not provided as a valid service account key file.");
+                }
+                return createGoogleCredential(serviceKeyContent, GcpCredentialType.GOOGLE_SERVICE_ACCOUNT_KEY_FILE);
+            } catch (IllegalArgumentException ex) {
+                throw new GcpException("SERVICE_ACCOUNT_VALUE is not provided in a valid base64 format.");
+            }
+        } else {
+            return creatApplicationDefaultCredentials();
+        }
+    }
+
+    /**
+     * Returns the Google Credentials which will created based on the Application Default Credentials in the following approaches
+     * - Credentials file pointed to by the GOOGLE_APPLICATION_CREDENTIALS environment variable
+     * - Credentials provided by the Google Cloud SDK gcloud auth application-default login command
+     * - Google App Engine built-in credentials
+     * - Google Cloud Shell built-in credentials
+     * - Google Compute Engine built-in credentials
+     *
+     * @return GoogleCredentials
+     */
+    public GoogleCredentials creatApplicationDefaultCredentials() {
+        return createGoogleCredential("", GcpCredentialType.DEFAULT_APPLICATION);
+    }
+
+
+    public GoogleCredentials createGoogleCredential(String keyContent, GcpCredentialType gcpCredentialType) {
+        GoogleCredentials googleCredentials;
+
+        if (gcpCredentialType.equals(GcpCredentialType.GOOGLE_ACCESS_TOKEN)) {
+            try {
+                var gcpAccessToken = typeManager.readValue(keyContent, GcpAccessToken.class);
+                monitor.info("Gcp: The provided token will be used to resolve the google credentials.");
+                googleCredentials = GoogleCredentials.create(
+                        new AccessToken(gcpAccessToken.getToken(),
+                                new Date(gcpAccessToken.getExpiration())));
+            } catch (EdcException ex) {
+                throw new GcpException("ACCESS_TOKEN is not in a valid GcpAccessToken format.");
+            } catch (Exception e) {
+                throw new GcpException("Error while getting the default credentials.", e);
+            }
+        } else if (gcpCredentialType.equals(GcpCredentialType.GOOGLE_SERVICE_ACCOUNT_KEY_FILE)) {
+            try {
+                monitor.debug("Gcp: The provided credentials file will be used to resolve the google credentials.");
+                googleCredentials = GoogleCredentials.fromStream(new ByteArrayInputStream(keyContent.getBytes(StandardCharsets.UTF_8)));
+            } catch (IOException e) {
+                throw new GcpException("Error while getting the credentials from the credentials file.", e);
+            }
+
+        } else {
+            try {
+                monitor.debug("Gcp: The default Credentials will be used to resolve the google credentials.");
+                googleCredentials = GoogleCredentials.getApplicationDefault();
+            } catch (IOException e) {
+                throw new GcpException("Error while getting the default credentials.", e);
+            }
+        }
+        return googleCredentials;
+    }
+}

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/GcsStoreSchema.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/GcsStoreSchema.java
@@ -18,10 +18,14 @@ public class GcsStoreSchema {
     public static final String TYPE = "GoogleCloudStorage";
     public static final String BUCKET_NAME = "bucket_name";
     public static final String LOCATION = "location";
+    public static final String PROJECT_ID = "project_id";
     public static final String STORAGE_CLASS = "storage_class";
     public static final String SERVICE_ACCOUNT_NAME = "service_account_name";
     public static final String SERVICE_ACCOUNT_EMAIL = "service_account_email";
     public static final String BLOB_NAME = "blob_name";
+    public static final String SERVICE_ACCOUNT_KEY_NAME = "service_account_key_name";
+    public static final String SERVICE_ACCOUNT_KEY_VALUE = "service_account_value";
+
 
     private GcsStoreSchema() {
     }

--- a/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/common/GcpCredentialsTest.java
+++ b/extensions/common/gcp/gcp-core/src/test/java/org/eclipse/edc/gcp/common/GcpCredentialsTest.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.gcp.common;
+
+import org.eclipse.edc.junit.testfixtures.MockVault;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class GcpCredentialsTest {
+
+    private GcpCredentials gcpCredential;
+
+    String accessTokenKeyName = "access_token_key_name_test";
+
+    String invalidAccessTokenKeyName = "invalid_access_token_key_name_test";
+
+    String serviceAccountKeyName = "service_account_key_name_test";
+
+    String invalidServiceAccountKeyName = "invalid_service_account_key_name_test";
+
+
+    private String serviceAccountFileInB64;
+
+    @BeforeEach
+    public void setUp() {
+        var vault = new MockVault();
+        var tokenValue = UUID.randomUUID();
+        var serviceAccountFileInJson = "{\n" +
+                "  \"type\": \"service_account\",\n" +
+                "  \"project_id\": \"project-test-1\",\n" +
+                "  \"private_key_id\": \"id1\",\n" +
+                "  \"private_key\": \"-----BEGIN PRIVATE KEY-----\\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQC6zzVgbCoFq0WS\\nhZBsaW70ntwOmSVfufvaNtVahXU1kLqJ+h5chwXENyQ5A4md941KS/x+lpK1Z/Nv" +
+                "\\nWwk/G7Uf5N5GI006JShKVsXeTl/CbAh8cLDHgG35ZXtFU24lWSDbdYu2qldxzJlL\\nr8E55ATsHwFBTezRwyTdsPNPS2F9Zx6fJme19WJMpkZDbImbxt8MxM1uI//6R0Xh\\nRqCvfnEGXRlj049uSKdRHExOCvp7EWEwfFznJqjFVUHbivR2p6szlq4dLkuexZko" +
+                "\\nEOSx2wWnzRW/NMg/5hqeLscbtyq7rjLfQTKcwTi4z8dymCHRf0RUzFX8ybgCt6y6\\nfpy8eY4/AgMBAAECgf8O4Mc02ITyCxWNpBWVcF50HRZpoXODOndw9+0GHfBGDMDO\\nkbmD+lltABO3zBBUdjguFjSF4HgkFviv8/O6WhcEne6kNZ1UhC9NvGKUJ1R5GVp3" +
+                "\\nOWX3YTTvRGzwfBge/c+R49j1pSmnEUDrYrCA+gujNGMsUE+aZTd8N6nT0ZCrCHbW\\niGeAAzjWZbQ+tx/ygotYGUDG5qqtQwZl52krKQ3OlMlmltcNddrLg/dBMeHu8g+S\\nbQivyd2QW0K9oglklreA6GnUUEOCt80hODIbBbpdyxVXcsDtNfffddqgf8j8xQm3" +
+                "\\npLUmufVW5gXlYnFogiSwKHPOvzmVPGyx/rBkmfkCgYEA4GSlIyE3vBSk+UkNa4zH\\n1sxUGq+3fi0vEEMsZsoOpsPPL4UJnktHnwiBkBsH5dIhLY/2NY9OHtIzMPTYvvRc\\nqG6RyQ61DTIjkVbNbfvpV4CAFnHRCh4ms/ZOukhegOfaRKNGADld1eUzsmShFTbV" +
+                "\\nuOZQLeE+PyEvJegCRya+AVkCgYEA1R9WdxbUq5bEyiU8euIOe8jCfICADFVQ957+\\noZ4XMprXX/uNBa2IIEgkXW2uWYCL09fL+UlVcUu5iyVqXaRLBzD3/JW9IfCzCm1A\\nxaMpezv1vLyZp0n0VvTN2uag6t5M/FkYCmp+m+VzQi82dFm0DuTFulOix78lYVHA" +
+                "\\nwFKbwVcCgYByqdtczS+e02nN3M+XwrOnhnf/vwTj3BDtnXXF/MBp5SstHC1jDxLF\\nKGKUkcuCW9MKZkMo8Va5Fy6DeMp9IX9rrjye4f4QhSt5rEKDTjPZu9c4IObx5aBf\\nW6C1Ph/UfSWi50/w81+I2nuFUDikD4Y82qvkFfJp7foaw6jOVPTI2QKBgQC7kZQY" +
+                "\\nxbgwuEXEH1eGUxQqL3uz9ag8so3LEVzLQwbpm8t4Bz2LRLnsp3GR5KkwzmjB7kfv\\nw3H2f43x/+EIP0NlNdzbqbHGgEAjKhp6luo4MoJJNLgKupTYPyY5xQbVDwc0hPka\\nmbWKYTu6gTDs39IP1ZqMLXWzVPCCIWCCI3I/iwKBgArrjiqmWQ55xRbdGCvw5RCv" +
+                "\\ncIyuvwZTRYGrkGDIq7HHcFQDTqcxMMQhe0ox9WgQDuu8hAsrVcJv2Ia/14W3xQPT\\nyGAc9EtS112c3ZOYCyuPY4NgoIad9TvpHvpiaLNukbIUAIimoNbyWAUwmkTjTjkC\\n4X+WEhgfmekYzcrk6nfS\\n-----END PRIVATE KEY-----\\n\",\n" +
+                "  \"client_email\": \"test@project-test-1.iam.gserviceaccount.com\",\n" +
+                "  \"client_id\": \"client_id1\",\n" +
+                "  \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\",\n" +
+                "  \"token_uri\": \"https://oauth2.googleapis.com/token\",\n" +
+                "  \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\",\n" +
+                "  \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/project-test-1.iam.gserviceaccount.com\"\n" +
+                "}";
+
+        var tokenInJson = "{\"edctype\":\"dataspaceconnector:gcptoken\"" +
+                ",\"token\":\"" + tokenValue + "\"," +
+                "\"expiration\":1665998128000}";
+        serviceAccountFileInB64 = Base64.getEncoder().encodeToString(serviceAccountFileInJson.getBytes());
+        var tokenInB64 = Base64.getEncoder().encodeToString(tokenInJson.getBytes());
+
+
+        vault.storeSecret(accessTokenKeyName, tokenInJson);
+        vault.storeSecret(invalidAccessTokenKeyName, "{\"token\":\"" + tokenValue + "\"");
+        vault.storeSecret(serviceAccountKeyName, serviceAccountFileInJson);
+        vault.storeSecret(invalidServiceAccountKeyName, "{\"type\": \"service_account\" }");
+        gcpCredential = new GcpCredentials(vault, new TypeManager(), mock(Monitor.class));
+    }
+
+    @Test
+    void testResolveGoogleCredentialWhenTokenKeyNameIsProvided() {
+        var gcpCred = gcpCredential.resolveGoogleCredentialsFromDataAddress(accessTokenKeyName, null, null);
+        assert (gcpCred != null);
+    }
+
+    @Test
+    void testResolveGoogleCredentialWhenInvalidTokenIsProvided() {
+        Exception thrown = assertThrows(EdcException.class, () -> gcpCredential.resolveGoogleCredentialsFromDataAddress(invalidAccessTokenKeyName,  null, null));
+        assert (thrown.getMessage().contains("valid GcpAccessToken format"));
+    }
+
+    @Test
+    void testResolveGoogleCredentialPriorityWhenTokenIsInvalid() {
+        Exception thrown = assertThrows(EdcException.class, () -> gcpCredential.resolveGoogleCredentialsFromDataAddress(invalidAccessTokenKeyName, serviceAccountKeyName, null));
+
+        assert (thrown.getMessage().contains("valid GcpAccessToken format"));
+    }
+
+
+    @Test
+    void testResolveGoogleCredentialWhenServiceAccountKeyNameIsProvided() {
+        var gcpCred = gcpCredential.resolveGoogleCredentialsFromDataAddress(null, serviceAccountKeyName, null);
+        assert (gcpCred != null);
+    }
+
+    @Test
+    void testResolveGoogleCredentialWhenInvalidServiceAccountKeyNameIsProvided() {
+        Exception thrown = assertThrows(GcpException.class, () -> gcpCredential.resolveGoogleCredentialsFromDataAddress(null,
+                invalidServiceAccountKeyName, null));
+    }
+
+    @Test
+    void testResolveGoogleCredentialWhenServiceAccountValueIsProvided() {
+        var gcpCred = gcpCredential.resolveGoogleCredentialsFromDataAddress(null, null, serviceAccountFileInB64);
+        assert (gcpCred != null);
+    }
+
+    @Test
+    void testResolveGoogleCredentialWhenInvalidServiceAccountValueIsProvided() {
+        Exception thrown = assertThrows(EdcException.class, () -> gcpCredential.resolveGoogleCredentialsFromDataAddress(null, null, serviceAccountFileInB64 + "makeItWrongB64"));
+        assert (thrown.getMessage().contains("valid base64 format"));
+    }
+
+    @Test
+    void testResolveGoogleCredentialPriorityWhenInvalidServiceAccountValueIsProvided() {
+        var gcpCred = gcpCredential.resolveGoogleCredentialsFromDataAddress(null, serviceAccountKeyName, serviceAccountFileInB64 + "makeItWrongB64");
+        assert (gcpCred != null);
+    }
+}

--- a/extensions/control-plane/provision/provision-gcs/README.md
+++ b/extensions/control-plane/provision/provision-gcs/README.md
@@ -1,23 +1,39 @@
+## Google cloud storage provisioner module
+
+### About this module
+This module contains a Data Plane extension to copy data to and from Google cloud storage.
+
 # Configure and run the EDC
 
 ### Authentication
+Google storage data plane supports three different approaches for authentication:
+* Default authentication:
+    * Authenticates against the Google Cloud API using the [Application Default Credentials](https://cloud.google.com/docs/authentication#adc).
+    * These will automatically be provided if the connector is deployed with the correct service account attached.
+* Service Account key file 
+    * Authentication using a Service Account key file exported from Google Cloud Platform
+    * Service Account key file can be stored in a vault or encoded as base64 and provided in the dataAddress.
 
-GcsProvisionerExtension authenticates against the Google Cloud API using
-the [Application Default Credentials](https://cloud.google.com/docs/authentication#adc).
-
-These will automatically be provided if the connector is deployed with the correct service account attached (see below
-in for the project setup and service account creation).
 
 ### Configuration
 
-| Key                | Description                      | Mandatory |
-|:-------------------|:---------------------------------|---|
-| edc.gcp.project.id | ID of the GCP projcet to be used | X |
+| Key                      | Description                                                                                                       | Mandatory |
+|:-------------------------|:------------------------------------------------------------------------------------------------------------------|-----------|
+| edc.gcp.project.id       | ID of the GCP projcet to be used for bucket and token creation. This can be difined in the DataAddress properties |  |
 
-# GCP Project Setup
+#### DataAddress properties
+| Key                      | Description                                                                                                                                                                      | Mandatory |
+|:-------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| type                     | GoogleCloudStorage                                                                                                                                                               | X    | 
+| project_id               | ID of the GCP projcet to be used for bucket and toekn creation. If the project_id has not been defined here, the projectId in the connector configurations will be used instead! |   | 
+| storage_class            | STANDARD/ NEARLINE/ COLDLINE/ ARCHIVE / [More info](https://cloud.google.com/storage/docs/storage-classes)                                                                       | X |
+| location                 | [Available regions](https://cloud.google.com/storage/docs/locations#location-r)                                                                                                  | X |
+| service_account_key_name | It should reference a vault entry containing a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json.            |  |
+| service_account_value    | It should contain a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json encoded with base64                    |  |
 
-For the provisioning to work we will need to run it with a service account with the correct permissions. There
-permissions are:
+# GCP Default authentication Setup
+
+For the provisioning to work we will need to run it with a service account with the correct permissions. The permissions are:
 
 - creating buckets
 - creating service accounts

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
@@ -14,21 +14,25 @@
 
 package org.eclipse.edc.connector.provision.gcp;
 
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
-import org.eclipse.edc.gcp.iam.IamServiceImpl;
-import org.eclipse.edc.gcp.storage.StorageServiceImpl;
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 
 
 public class GcsProvisionExtension implements ServiceExtension {
 
-    @Setting(value = "The GCP project ID", required = true)
+    @Override
+    public String name() {
+        return "GCP storage provisioner";
+    }
+
+    @Setting(value = "The GCP project ID", required = false)
     private static final String GCP_PROJECT_ID = "edc.gcp.project.id";
 
     @Inject
@@ -37,34 +41,22 @@ public class GcsProvisionExtension implements ServiceExtension {
     @Inject
     private ResourceManifestGenerator manifestGenerator;
 
-    @Override
-    public String name() {
-        return "GCP storage provisioner";
-    }
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private Vault vault;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
-
         var projectId = context.getConfig().getString(GCP_PROJECT_ID);
-        var storageClient = createDefaultStorageClient(projectId);
-        var storageService = new StorageServiceImpl(storageClient, monitor);
-        var iamService = IamServiceImpl.Builder.newInstance(monitor, projectId).build();
+        var gcpCredential = new GcpCredentials(vault, typeManager, monitor);
 
-        var provisioner = new GcsProvisioner(monitor, storageService, iamService);
+        var provisioner = new GcsProvisioner(monitor, gcpCredential, projectId);
         provisionManager.register(provisioner);
 
         manifestGenerator.registerGenerator(new GcsConsumerResourceDefinitionGenerator());
-    }
-
-
-    /**
-     * Creates {@link Storage} for the specified project using application default credentials
-     *
-     * @param projectId The project that should be used for storage operations
-     * @return {@link Storage}
-     */
-    private Storage createDefaultStorageClient(String projectId) {
-        return StorageOptions.newBuilder().setProjectId(projectId).build().getService();
     }
 }

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionedResource.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionedResource.java
@@ -23,14 +23,17 @@ import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.BUCKET_NAME;
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.LOCATION;
+import static org.eclipse.edc.gcp.storage.GcsStoreSchema.PROJECT_ID;
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.SERVICE_ACCOUNT_EMAIL;
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.SERVICE_ACCOUNT_NAME;
 import static org.eclipse.edc.gcp.storage.GcsStoreSchema.STORAGE_CLASS;
 
+
+
+
 @JsonDeserialize(builder = GcsProvisionedResource.Builder.class)
 @JsonTypeName("dataspaceconnector:gcsgrovisionedresource")
 public class GcsProvisionedResource extends ProvisionedDataDestinationResource {
-
     private GcsProvisionedResource() {
     }
 
@@ -40,6 +43,10 @@ public class GcsProvisionedResource extends ProvisionedDataDestinationResource {
 
     public String getLocation() {
         return getDataAddress().getProperty(LOCATION);
+    }
+
+    public String getProjectId() {
+        return getDataAddress().getProperty(PROJECT_ID);
     }
 
     public String getStorageClass() {
@@ -75,6 +82,11 @@ public class GcsProvisionedResource extends ProvisionedDataDestinationResource {
 
         public GcsProvisionedResource.Builder location(String location) {
             dataAddressBuilder.property(LOCATION, location);
+            return this;
+        }
+
+        public GcsProvisionedResource.Builder projectId(String projectId) {
+            this.dataAddressBuilder.property(PROJECT_ID, projectId);
             return this;
         }
 

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisioner.java
@@ -14,37 +14,51 @@
 
 package org.eclipse.edc.connector.provision.gcp;
 
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.iam.admin.v1.IAMClient;
+import com.google.cloud.iam.admin.v1.IAMSettings;
+import com.google.cloud.iam.credentials.v1.IamCredentialsClient;
+import com.google.cloud.iam.credentials.v1.IamCredentialsSettings;
+import com.google.cloud.iam.credentials.v1.stub.IamCredentialsStubSettings;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import org.eclipse.edc.connector.transfer.spi.provision.Provisioner;
 import org.eclipse.edc.connector.transfer.spi.types.DeprovisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
-import org.eclipse.edc.gcp.common.GcpAccessToken;
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.common.GcpException;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
-import org.eclipse.edc.gcp.common.GcsBucket;
 import org.eclipse.edc.gcp.iam.IamService;
+import org.eclipse.edc.gcp.iam.IamServiceImpl;
+import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.gcp.storage.StorageService;
+import org.eclipse.edc.gcp.storage.StorageServiceImpl;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsProvisionedResource> {
 
     private final Monitor monitor;
-    private final StorageService storageService;
-    private final IamService iamService;
+    private final GcpCredentials gcpCredential;
+    private @Nullable String projectId;
 
-    public GcsProvisioner(Monitor monitor, StorageService storageService, IamService iamService) {
+    public GcsProvisioner(Monitor monitor, GcpCredentials gcpCredential, @Nullable String projectId) {
         this.monitor = monitor;
-        this.storageService = storageService;
-        this.iamService = iamService;
+        this.gcpCredential = gcpCredential;
+        this.projectId = projectId;
     }
 
     @Override
@@ -60,6 +74,24 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
     @Override
     public CompletableFuture<StatusResult<ProvisionResponse>> provision(
             GcsResourceDefinition resourceDefinition, Policy policy) {
+
+        var projectId = getProjectId(resourceDefinition.getProjectId());
+        var dataAddress = resourceDefinition.getDataAddress();
+        var googleCredentials = gcpCredential.resolveGoogleCredentialsFromDataAddress(dataAddress.getKeyName(),
+                dataAddress.getProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_NAME),
+                dataAddress.getProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_VALUE));
+
+        var iamService = createIamService(monitor,
+                projectId, googleCredentials);
+
+        var storageClient = createStorageClient(googleCredentials);
+        var storageService = new StorageServiceImpl(storageClient, monitor);
+        return provision(resourceDefinition, policy, iamService, storageService);
+    }
+
+     public CompletableFuture<StatusResult<ProvisionResponse>> provision(
+            GcsResourceDefinition resourceDefinition, Policy policy,
+            IamService iamService, StorageService storageService) {
         var bucketName = resourceDefinition.getId();
         var bucketLocation = resourceDefinition.getLocation();
 
@@ -72,8 +104,10 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
             if (!storageService.isEmpty(bucketName)) {
                 return completedFuture(StatusResult.failure(ResponseStatus.FATAL_ERROR, String.format("Bucket: %s already exists and is not empty.", bucketName)));
             }
-            var serviceAccount = createServiceAccount(processId, bucketName);
-            var token = createBucketAccessToken(bucket, serviceAccount);
+
+            var serviceAccount = createServiceAccount(processId, bucketName, iamService);
+            storageService.addProviderPermissions(bucket, serviceAccount);
+            var token = iamService.createAccessToken(serviceAccount);
 
             var resource = getProvisionedResource(resourceDefinition, resourceName, bucketName, serviceAccount);
 
@@ -84,9 +118,53 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
         }
     }
 
+    /**
+     * Supplier of {@link IAMClient} using application default credentials
+     */
+    private Supplier<IAMClient> getIamClientSupplier(GoogleCredentials googleCredentials) {
+        return () -> {
+            try {
+                var iamSetting = IAMSettings.newBuilder()
+                        .setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials))
+                        .build();
+                return IAMClient.create(iamSetting);
+            } catch (IOException e) {
+                throw new GcpException("Error while creating IAMClient", e);
+            }
+        };
+    }
+
+    /**
+     * Supplier of {@link IamCredentialsClient} using application default credentials
+     */
+    private Supplier<IamCredentialsClient> getIamCredentialsClientSupplier(GoogleCredentials googleCredentials) {
+
+        return () -> {
+            try {
+                var iamCredentialsStubSettings = IamCredentialsStubSettings.newBuilder()
+                        .setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials))
+                        .build();
+                return IamCredentialsClient.create(IamCredentialsSettings.create(iamCredentialsStubSettings));
+            } catch (IOException e) {
+                throw new GcpException("Error while creating IamCredentialsClient", e);
+            }
+        };
+    }
+
+
     @Override
     public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(
             GcsProvisionedResource provisionedResource, Policy policy) {
+        var dataAddress = provisionedResource.getDataAddress();
+        var googleCredentials = gcpCredential.resolveGoogleCredentialsFromDataAddress(dataAddress.getKeyName(),
+                dataAddress.getProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_NAME),
+                dataAddress.getProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_VALUE));
+        var projectId = getProjectId(provisionedResource.getProjectId());
+        var iamService = createIamService(monitor, projectId, googleCredentials);
+        return deprovision(provisionedResource, iamService);
+    }
+
+    public CompletableFuture<StatusResult<DeprovisionedResource>> deprovision(GcsProvisionedResource provisionedResource, IamService iamService) {
         try {
             iamService.deleteServiceAccountIfExists(
                     new GcpServiceAccount(provisionedResource.getServiceAccountEmail(),
@@ -98,9 +176,21 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
         return CompletableFuture.completedFuture(StatusResult.success(
                 DeprovisionedResource.Builder.newInstance()
                         .provisionedResourceId(provisionedResource.getId()).build()));
+
     }
 
-    private GcpServiceAccount createServiceAccount(String processId, String buckedName) {
+    private String getProjectId(@Nullable String projectId) {
+        if (projectId != null && !projectId.isEmpty()) {
+            return projectId;
+        } else if (this.projectId != null && !this.projectId.isEmpty()) {
+            return this.projectId;
+        } else {
+            throw new GcpException("ProjectId is empty. It must be provided either in the configs or asset properties!");
+        }
+
+    }
+
+    private GcpServiceAccount createServiceAccount(String processId, String buckedName, IamService iamService) {
         var serviceAccountName = sanitizeServiceAccountName(processId);
         var uniqueServiceAccountDescription = generateUniqueServiceAccountDescription(processId, buckedName);
         return iamService.getOrCreateServiceAccount(serviceAccountName, uniqueServiceAccountDescription);
@@ -120,16 +210,12 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
         return String.format("transferProcess:%s\nbucket:%s", transferProcessId, bucketName);
     }
 
-    private GcpAccessToken createBucketAccessToken(GcsBucket bucket, GcpServiceAccount serviceAccount) {
-        storageService.addProviderPermissions(bucket, serviceAccount);
-        return iamService.createAccessToken(serviceAccount);
-    }
-
     private GcsProvisionedResource getProvisionedResource(GcsResourceDefinition resourceDefinition, String resourceName, String bucketName, GcpServiceAccount serviceAccount) {
         return GcsProvisionedResource.Builder.newInstance()
                 .id(resourceDefinition.getId())
                 .resourceDefinitionId(resourceDefinition.getId())
                 .location(resourceDefinition.getLocation())
+                .projectId(resourceDefinition.getProjectId())
                 .storageClass(resourceDefinition.getStorageClass())
                 .serviceAccountEmail(serviceAccount.getEmail())
                 .serviceAccountName(serviceAccount.getName())
@@ -137,5 +223,23 @@ public class GcsProvisioner implements Provisioner<GcsResourceDefinition, GcsPro
                 .resourceName(resourceName)
                 .bucketName(bucketName)
                 .hasToken(true).build();
+    }
+
+    /**
+     * Creates {@link Storage} for the specified project using application default credentials
+     *
+     * @param googleCredentials Google credentials
+     * @return {@link Storage}
+     */
+    private Storage createStorageClient(GoogleCredentials googleCredentials) {
+        return StorageOptions.newBuilder()
+                .setCredentials(googleCredentials).build().getService();
+    }
+
+    private IamService createIamService(Monitor monitor, String projectId, GoogleCredentials googleCredentials) {
+        return IamServiceImpl.Builder.newInstance(monitor, projectId)
+                .iamClientSupplier(getIamClientSupplier(googleCredentials))
+                .iamCredentialsClientSupplier(getIamCredentialsClientSupplier(googleCredentials))
+                .build();
     }
 }

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsResourceDefinition.java
@@ -15,19 +15,32 @@
 package org.eclipse.edc.connector.provision.gcp;
 
 import org.eclipse.edc.connector.transfer.spi.types.ResourceDefinition;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 
 import java.util.Objects;
 
 public class GcsResourceDefinition extends ResourceDefinition {
 
+    private DataAddress dataAddress;
     private String location;
+
+    private String projectId;
     private String storageClass;
+
 
     private GcsResourceDefinition() {
     }
 
+    public DataAddress getDataAddress() {
+        return dataAddress;
+    }
+
     public String getLocation() {
         return this.location;
+    }
+
+    public String getProjectId() {
+        return this.projectId;
     }
 
     public String getStorageClass() {
@@ -37,7 +50,9 @@ public class GcsResourceDefinition extends ResourceDefinition {
     @Override
     public Builder toBuilder() {
         return initializeBuilder(new Builder())
+                .dataAddress(dataAddress)
                 .location(location)
+                .projectId(projectId)
                 .storageClass(storageClass);
     }
 
@@ -51,8 +66,18 @@ public class GcsResourceDefinition extends ResourceDefinition {
             return new Builder();
         }
 
+        public Builder dataAddress(DataAddress dataAddress) {
+            resourceDefinition.dataAddress = dataAddress;
+            return this;
+        }
+
         public Builder location(String location) {
             resourceDefinition.location = location;
+            return this;
+        }
+
+        public Builder projectId(String projectId) {
+            resourceDefinition.projectId = projectId;
             return this;
         }
 

--- a/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
+++ b/extensions/control-plane/provision/provision-gcs/src/test/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerTest.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.connector.provision.gcp;
 
+
 import org.eclipse.edc.gcp.common.GcpAccessToken;
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.common.GcpException;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
 import org.eclipse.edc.gcp.common.GcsBucket;
@@ -30,6 +32,7 @@ import org.mockito.ArgumentMatcher;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.anyString;
@@ -43,6 +46,7 @@ import static org.mockito.Mockito.when;
 
 class GcsProvisionerTest {
 
+
     private GcsProvisioner provisioner;
     private StorageService storageServiceMock;
     private IamService iamServiceMock;
@@ -53,7 +57,7 @@ class GcsProvisionerTest {
         storageServiceMock = mock(StorageService.class);
         iamServiceMock = mock(IamService.class);
         testPolicy = Policy.Builder.newInstance().build();
-        provisioner = new GcsProvisioner(mock(Monitor.class), storageServiceMock, iamServiceMock);
+        provisioner = new GcsProvisioner(mock(Monitor.class), mock(GcpCredentials.class), null);
     }
 
     @Test
@@ -65,13 +69,27 @@ class GcsProvisionerTest {
     }
 
     @Test
-    void provisionSuccess() {
+    void provisionSuccessWithoutProjectId() {
         var resourceDefinitionId = "id";
         var location = "location";
         var storageClass = "storage-class";
         var transferProcessId = UUID.randomUUID().toString();
         var resourceDefinition = createResourceDefinition(resourceDefinitionId, location,
-                storageClass, transferProcessId);
+                storageClass, transferProcessId, null);
+        assertThatExceptionOfType(GcpException.class).isThrownBy(() ->
+                provisioner.provision(resourceDefinition, testPolicy));
+
+    }
+
+    @Test
+    void provisionSuccess() {
+        var resourceDefinitionId = "id";
+        var location = "location";
+        var storageClass = "storage-class";
+        var projectId = "projectIdTest";
+        var transferProcessId = UUID.randomUUID().toString();
+        var resourceDefinition = createResourceDefinition(resourceDefinitionId, location,
+                storageClass, transferProcessId, projectId);
         var bucketName = resourceDefinition.getId();
         var bucketLocation = resourceDefinition.getLocation();
 
@@ -85,17 +103,17 @@ class GcsProvisionerTest {
         doNothing().when(storageServiceMock).addProviderPermissions(bucket, serviceAccount);
         when(iamServiceMock.createAccessToken(serviceAccount)).thenReturn(token);
 
-        var response = provisioner.provision(resourceDefinition, testPolicy).join().getContent();
+        var response = provisioner.provision(resourceDefinition, testPolicy, iamServiceMock, storageServiceMock).join().getContent();
 
         assertThat(response.getResource()).isInstanceOfSatisfying(GcsProvisionedResource.class, resource -> {
             assertThat(resource.getId()).isEqualTo(resourceDefinitionId);
             assertThat(resource.getTransferProcessId()).isEqualTo(transferProcessId);
             assertThat(resource.getLocation()).isEqualTo(location);
             assertThat(resource.getStorageClass()).isEqualTo(storageClass);
+            assertThat(resource.getProjectId()).isEqualTo(projectId);
         });
-        assertThat(response.getSecretToken()).isInstanceOfSatisfying(GcpAccessToken.class, secretToken -> {
-            assertThat(secretToken.getToken()).isEqualTo("token");
-        });
+
+        assertThat(response.getSecretToken()).isInstanceOfSatisfying(GcpAccessToken.class, secretToken -> assertThat(secretToken.getToken()).isEqualTo("token"));
 
         verify(storageServiceMock).getOrCreateEmptyBucket(bucketName, bucketLocation);
         verify(storageServiceMock).addProviderPermissions(bucket, serviceAccount);
@@ -111,7 +129,7 @@ class GcsProvisionerTest {
         when(storageServiceMock.getOrCreateEmptyBucket(bucketName, bucketLocation)).thenReturn(new GcsBucket(bucketName));
         when(storageServiceMock.isEmpty(bucketName)).thenReturn(false);
 
-        var response = provisioner.provision(resourceDefinition, testPolicy).join();
+        var response = provisioner.provision(resourceDefinition, testPolicy, iamServiceMock, storageServiceMock).join();
 
         assertThat(response.failed()).isTrue();
         assertThat(response.getFailure().status()).isEqualTo(ResponseStatus.FATAL_ERROR);
@@ -130,7 +148,7 @@ class GcsProvisionerTest {
 
         doThrow(new GcpException("some error")).when(storageServiceMock).getOrCreateEmptyBucket(bucketName, bucketLocation);
 
-        var response = provisioner.provision(resourceDefinition, testPolicy).join();
+        var response = provisioner.provision(resourceDefinition, testPolicy, iamServiceMock, storageServiceMock).join();
         assertThat(response.failed()).isTrue();
     }
 
@@ -152,10 +170,28 @@ class GcsProvisionerTest {
         doNothing().when(iamServiceMock).deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
         var resource = createGcsProvisionedResource(email, name, id);
 
-        var response = provisioner.deprovision(resource, testPolicy).join().getContent();
+        var response = provisioner.deprovision(resource, iamServiceMock).join().getContent();
         verify(iamServiceMock).deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
         assertThat(response.getProvisionedResourceId()).isEqualTo(id);
     }
+
+    @Test
+    void deprovisionFailIfProjectIdIsNotProvided() {
+        var resource = GcsProvisionedResource.Builder.newInstance().resourceName("name")
+                .id("test-id")
+                .resourceDefinitionId("test-id")
+                .bucketName("bucket")
+                .location("location")
+                .storageClass("standard")
+                .transferProcessId("transfer-id")
+                .serviceAccountName("test-name")
+                .serviceAccountEmail("test-name")
+                .build();
+
+        assertThatExceptionOfType(GcpException.class).isThrownBy(() ->
+                provisioner.deprovision(resource, testPolicy));
+    }
+
 
     private GcsProvisionedResource createGcsProvisionedResource(String serviceAccountEmail, String serviceAccountName, String id) {
         return GcsProvisionedResource.Builder.newInstance().resourceName("name")
@@ -165,6 +201,7 @@ class GcsProvisionerTest {
                 .location("location")
                 .storageClass("standard")
                 .transferProcessId("transfer-id")
+                .projectId("project-id")
                 .serviceAccountName(serviceAccountName)
                 .serviceAccountEmail(serviceAccountEmail)
                 .build();
@@ -172,13 +209,14 @@ class GcsProvisionerTest {
 
     private GcsResourceDefinition createResourceDefinition() {
         return createResourceDefinition("id", "location",
-                "storage-class", "transfer-id");
+                "storage-class", "transfer-id", "projectId-test");
     }
 
-    private GcsResourceDefinition createResourceDefinition(String id, String location, String storageClass, String transferProcessId) {
+    private GcsResourceDefinition createResourceDefinition(String id, String location, String storageClass, String transferProcessId, String projectId) {
         return GcsResourceDefinition.Builder.newInstance().id(id)
                 .location(location).storageClass(storageClass)
-                .transferProcessId(transferProcessId).build();
+                .transferProcessId(transferProcessId)
+                .projectId(projectId).build();
     }
 
     @Test
@@ -193,7 +231,7 @@ class GcsProvisionerTest {
         doThrow(new GcpException("some error"))
                 .when(iamServiceMock)
                 .deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
-        var response = provisioner.deprovision(resource, testPolicy).join();
+        var response = provisioner.deprovision(resource, iamServiceMock).join();
 
         verify(iamServiceMock).deleteServiceAccountIfExists(argThat(matches(serviceAccount)));
         assertThat(response.failed()).isTrue();

--- a/extensions/data-plane/data-plane-google-storage/README.md
+++ b/extensions/data-plane/data-plane-google-storage/README.md
@@ -5,26 +5,35 @@
 This module contains a Data Plane extension to copy data to and from Google cloud storage.
 
 ### Authentication
+Google storage data plane supports three different approaches for authentication:
+* Default authentication:
+  * Authenticates against the Google Cloud API using the [Application Default Credentials](https://cloud.google.com/docs/authentication#adc).
+  * These will automatically be provided if the connector is deployed with the correct service account attached.
+* Service Account key file
+  * Authentication using a Service Account key file exported from Google Cloud Platform
+  * Service Account key file can be stored in a vault or encoded as base64 and provided in the dataAddress.
 
-Currently, Google storage data plane only authenticates against the Google Cloud API using
-the [Application Default Credentials](https://cloud.google.com/docs/authentication#adc).
-
-These will automatically be provided if the connector is deployed with the correct service account attached.
 
 ### Data source properties
 
-| Key               | Description                                                               | Mandatory |
-|:------------------|:--------------------------------------------------------------------------|---|
-| type | GoogleCloudStorage                                                        | X |
-| bucket_name | A valid name of your bucket                                               | X |
-| blob_name | Name of your blob/object in the bucket. Currently only a single blob name | X |
+| Key                      | Description                                                                                                                                                                                                                                                                                                                                                            | Mandatory |
+|:-------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| type                     | GoogleCloudStorage                                                                                                                                                                                                                                                                                                                                                     | X |
+| bucket_name              | A valid name of your bucket                                                                                                                                                                                                                                                                                                                                            | X |
+| blob_name                | Name of your blob/object in the bucket. Currently only a single blob name                                                                                                                                                                                                                                                                                              | X |
+| service_account_key_name | It should reference a vault entry containing a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json.            |  |
+| service_account_value    | It should contain a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json encoded with base64                    |  |
 
-### Data destination properties
+### Data destination properties without Google provisioner
 
-| Key               | Description                                                                                                | Mandatory with provisioner | Mandatory without provisioner |
-|:------------------|:-----------------------------------------------------------------------------------------------------------|----------------------------|---------------------------|
-| type | GoogleCloudStorage                                                                                         | X                          | X                         |
-| bucket_name | A valid name of your bucket                                                                                |                           | X                         |
-| blob_name | Name of your blob/object in the bucket. The source blob name will be used if it is not provided!           |                           |                           |
-| storage_class | STANDARD/ NEARLINE/ COLDLINE/ ARCHIVE / [More info](https://cloud.google.com/storage/docs/storage-classes) | X                          |                           |
-| location | [Available regions](https://cloud.google.com/storage/docs/locations#location-r)                            | X                          |                           |
+| Key               | Description                                                                                                    | Mandatory with provisioner | Mandatory without provisioner |
+|:------------------|:---------------------------------------------------------------------------------------------------------------|----------------------------|---------------------------|
+| type | GoogleCloudStorage                                                                                             | X                          | X                         |
+| bucket_name | A valid name of your bucket                                                                                    |                           | X                         |
+| blob_name | Name of your blob/object in the bucket. The source blob name will be used if it is not provided!               |                           |                           |
+| storage_class | STANDARD/ NEARLINE/ COLDLINE/ ARCHIVE / [More info](https://cloud.google.com/storage/docs/storage-classes)     | X                          |                           |
+| location | [Available regions](https://cloud.google.com/storage/docs/locations#location-r)                                | X                          |                           |
+| service_account_key_name | It should reference a vault entry containing a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json.            |  |
+| service_account_value    | It should contain a [Service Account Key File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating) in json encoded with base64                    |  |
+
+### [Data destination properties with Google provisioner](../../control-plane/provision/provision-gcs/README.md)

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/DataPlaneGcsExtension.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/DataPlaneGcsExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.dataplane.gcp.storage;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.security.Vault;
@@ -25,7 +26,6 @@ import org.eclipse.edc.spi.types.TypeManager;
 
 @Extension(value = DataPlaneGcsExtension.NAME)
 public class DataPlaneGcsExtension implements ServiceExtension {
-
     public static final String NAME = "Data Plane Google Cloud Storage";
 
     @Inject
@@ -47,13 +47,14 @@ public class DataPlaneGcsExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-
         var monitor = context.getMonitor();
+        var gcpCredential = new GcpCredentials(vault, typeManager, monitor);
 
-        var sourceFactory = new GcsDataSourceFactory(monitor);
+
+        var sourceFactory = new GcsDataSourceFactory(monitor, gcpCredential);
         pipelineService.registerFactory(sourceFactory);
 
-        var sinkFactory = new GcsDataSinkFactory(executorContainer.getExecutorService(), monitor, vault, typeManager);
+        var sinkFactory = new GcsDataSinkFactory(executorContainer.getExecutorService(), monitor, gcpCredential);
         pipelineService.registerFactory(sinkFactory);
     }
 }

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactory.java
@@ -15,44 +15,32 @@
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
 
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.eclipse.edc.connector.dataplane.gcp.storage.validation.GcsSinkDataAddressValidationRule;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
 import org.eclipse.edc.connector.dataplane.util.validation.ValidationRule;
-import org.eclipse.edc.gcp.common.GcpAccessToken;
-import org.eclipse.edc.gcp.common.GcpException;
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.security.Vault;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
-import java.util.Date;
 import java.util.concurrent.ExecutorService;
 
 public class GcsDataSinkFactory implements DataSinkFactory {
-
     private final ValidationRule<DataAddress> validation = new GcsSinkDataAddressValidationRule();
     private final ExecutorService executorService;
     private final Monitor monitor;
-    private final Vault vault;
-    private final TypeManager typeManager;
+    private final GcpCredentials gcpCredential;
 
-
-    public GcsDataSinkFactory(ExecutorService executorService, Monitor monitor, Vault vault, TypeManager typeManager) {
+    public GcsDataSinkFactory(ExecutorService executorService, Monitor monitor, GcpCredentials gcpCredential) {
         this.executorService = executorService;
         this.monitor = monitor;
-        this.vault = vault;
-        this.typeManager = typeManager;
+        this.gcpCredential = gcpCredential;
     }
 
     @Override
@@ -72,10 +60,16 @@ public class GcsDataSinkFactory implements DataSinkFactory {
         if (validationResult.failed()) {
             throw new EdcException(String.join(", ", validationResult.getFailureMessages()));
         }
+        var destinationDataAddress = request.getDestinationDataAddress();
+        var googleCredentials = gcpCredential.resolveGoogleCredentialsFromDataAddress(destinationDataAddress.getKeyName(),
+                destinationDataAddress.getProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_NAME),
+                destinationDataAddress.getProperty(GcsStoreSchema.SERVICE_ACCOUNT_KEY_VALUE));
 
         var destination = request.getDestinationDataAddress();
 
-        var storageClient = createStorageClient(destination.getKeyName());
+        var storageClient = StorageOptions.newBuilder()
+                .setCredentials(googleCredentials)
+                .build().getService();
 
         return GcsDataSink.Builder.newInstance()
                 .storageClient(storageClient)
@@ -85,28 +79,5 @@ public class GcsDataSinkFactory implements DataSinkFactory {
                 .executorService(executorService)
                 .monitor(monitor)
                 .build();
-    }
-
-    private Storage createStorageClient(String keyName) {
-        GoogleCredentials googleCredentials;
-        //Get credential from the token if it exists in the vault otherwise use the default credentials of the system.
-        if (keyName != null && !keyName.isEmpty()) {
-            var credentialsContent = vault.resolveSecret(keyName);
-            var gcsAccessToken = typeManager.readValue(credentialsContent, GcpAccessToken.class);
-            googleCredentials = GoogleCredentials.create(
-                    new AccessToken(gcsAccessToken.getToken(),
-                            new Date(gcsAccessToken.getExpiration()))
-            );
-        } else {
-            try {
-                googleCredentials = GoogleCredentials.getApplicationDefault();
-            } catch (IOException e) {
-                throw new GcpException("Error while getting the default credentials.", e);
-            }
-        }
-
-        return StorageOptions.newBuilder()
-                .setCredentials(googleCredentials)
-                .build().getService();
     }
 }

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSinkFactoryTest.java
@@ -14,10 +14,9 @@
 
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.security.Vault;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowRequest;
 import org.junit.jupiter.api.Test;
@@ -37,9 +36,7 @@ class GcsDataSinkFactoryTest {
     private final GcsDataSinkFactory factory = new GcsDataSinkFactory(
             mock(ExecutorService.class),
             mock(Monitor.class),
-            mock(Vault.class),
-            new TypeManager()
-    );
+            mock(GcpCredentials.class));
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {

--- a/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-google-storage/src/test/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSourceFactoryTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
+import org.eclipse.edc.gcp.common.GcpCredentials;
 import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,7 @@ class GcsDataSourceFactoryTest {
     Monitor monitor = mock(Monitor.class);
 
     private final GcsDataSourceFactory factory =
-            new GcsDataSourceFactory(monitor);
+            new GcsDataSourceFactory(monitor, mock(GcpCredentials.class));
 
     @Test
     void canHandle_returnsTrueWhenExpectedType() {


### PR DESCRIPTION
… allow runtime changes to projectId and credentials. (#2115)
#### Changes from the review of https://github.com/git-masoud/DataSpaceConnector/pull/1:
* ProjectId can be defined in configurations and in the dataAddress properties
* resolveGoogleCredentialsFromDataAddress is more explicit now
* Enhancing ReadMe
* Logs changed to debug

