### PR TITLE
Feature/2115 gcs enhancement

### DIFF
--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageService.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.edc.gcp.storage;
 
+import com.google.api.gax.paging.Page;
+
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import org.eclipse.edc.gcp.common.GcpServiceAccount;
 import org.eclipse.edc.gcp.common.GcsBucket;
@@ -66,4 +69,11 @@ public interface StorageService {
      * @return true if the bucket is empty and false if not
      */
     boolean isEmpty(String bucketName);
+
+    /**
+     * Returns the list of Blobs in the bucket
+     * @param bucketName The name of the bucket
+     * @return the list of Blob items stored in the bucket
+     */
+    Page<Blob> list(String bucketName);
 }

--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/storage/StorageServiceImpl.java
@@ -14,7 +14,10 @@
 
 package org.eclipse.edc.gcp.storage;
 
+import com.google.api.gax.paging.Page;
+
 import com.google.cloud.Binding;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import org.eclipse.edc.gcp.common.GcpException;
@@ -87,8 +90,13 @@ public class StorageServiceImpl implements StorageService {
     }
 
     @Override
-    public boolean isEmpty(String bucket) {
-        var blobs = storageClient.list(bucket, Storage.BlobListOption.pageSize(1)).getValues();
+    public boolean isEmpty(String bucketName) {
+        var blobs = storageClient.list(bucketName, Storage.BlobListOption.pageSize(1)).getValues();
         return !blobs.iterator().hasNext();
+    }
+
+    @Override
+    public Page<Blob> list(String bucketName) {
+        return storageClient.list(bucketName);
     }
 }

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionExtension.java
@@ -14,9 +14,14 @@
 
 package org.eclipse.edc.connector.provision.gcp;
 
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.eclipse.edc.gcp.storage.GcsStoreSchema;
 import org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager;
 import org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator;
+import org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry;
 import org.eclipse.edc.gcp.common.GcpCredentials;
+import org.eclipse.edc.gcp.storage.StorageServiceImpl;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.security.Vault;
@@ -41,22 +46,41 @@ public class GcsProvisionExtension implements ServiceExtension {
     @Inject
     private ResourceManifestGenerator manifestGenerator;
 
-
     @Inject
     private TypeManager typeManager;
 
     @Inject
     private Vault vault;
 
+    @Inject
+    private StatusCheckerRegistry statusCheckerRegistry;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
         var projectId = context.getConfig().getString(GCP_PROJECT_ID);
-        var gcpCredential = new GcpCredentials(vault, typeManager, monitor);
 
+        var gcpCredential = new GcpCredentials(vault, typeManager, monitor);
+        // var iamService = IamServiceImpl.Builder.newInstance(monitor, projectId).build();
+
+        // var provisioner = new GcsProvisioner(monitor, storageService, iamService);
         var provisioner = new GcsProvisioner(monitor, gcpCredential, projectId);
         provisionManager.register(provisioner);
 
         manifestGenerator.registerGenerator(new GcsConsumerResourceDefinitionGenerator());
+
+        var storageClient = createDefaultStorageClient(projectId);
+        var storageService = new StorageServiceImpl(storageClient, monitor);
+        statusCheckerRegistry.register(GcsStoreSchema.TYPE, new GcsProvisionerStatusChecker(storageService));
+    }
+
+   /**
+     * Creates {@link Storage} for the specified project using application default credentials
+     *
+     * @param projectId The project that should be used for storage operations
+     * @return {@link Storage}
+     */
+    private Storage createDefaultStorageClient(String projectId) {
+        return StorageOptions.newBuilder().setProjectId(projectId).build().getService();
     }
 }

--- a/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusChecker.java
+++ b/extensions/control-plane/provision/provision-gcs/src/main/java/org/eclipse/edc/connector/provision/gcp/GcsProvisionerStatusChecker.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2022 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.connector.provision.gcp;
+
+import com.google.cloud.storage.Blob;
+
+import java.util.Iterator;
+
+import org.eclipse.edc.gcp.storage.GcsStoreSchema;
+import org.eclipse.edc.connector.transfer.spi.types.ProvisionedResource;
+import org.eclipse.edc.connector.transfer.spi.types.StatusChecker;
+import org.eclipse.edc.connector.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.gcp.storage.StorageServiceImpl;
+import org.eclipse.edc.spi.EdcException;
+
+import java.util.List;
+
+import static org.eclipse.edc.connector.transfer.spi.types.TransferProcess.Type.PROVIDER;
+
+import static java.lang.String.format;
+
+public class GcsProvisionerStatusChecker implements StatusChecker {
+    private StorageServiceImpl storageService;
+
+    public GcsProvisionerStatusChecker(StorageServiceImpl storageService) {
+        this.storageService = storageService;
+    }
+
+    @Override
+    public boolean isComplete(TransferProcess transferProcess, List<ProvisionedResource> resources) {
+        if (transferProcess.getType() == PROVIDER) {
+            // TODO check if PROVIDER process implementation is needed
+        }
+
+        var bucketName = transferProcess.getDataRequest().getDataDestination().getProperty(GcsStoreSchema.BUCKET_NAME);
+        if (resources != null && !resources.isEmpty()) {
+            for (var resource : resources) {
+                if (resource instanceof GcsProvisionedResource) {
+                    return checkBucketTransferComplete(bucketName);
+                }
+            }
+        } else {
+            return checkBucketTransferComplete(bucketName);
+        }
+        throw new EdcException(format("Cannot determine completion: no resource associated with transfer process %s.", transferProcess));
+    }
+
+    private boolean checkBucketTransferComplete(String bucketName) {
+        String testBlobName = bucketName+".complete";
+        var blobs = storageService.list(bucketName);
+        // TODO rewrite with stream
+        Iterator<Blob> blobIterator = blobs.iterateAll().iterator();
+        while (blobIterator.hasNext()) {
+            Blob blob = blobIterator.next();
+            if (blob.getName().equals(testBlobName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSink.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSink.java
@@ -23,6 +23,8 @@ import org.eclipse.edc.connector.dataplane.util.sink.ParallelSink;
 import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.util.List;

--- a/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSource.java
+++ b/extensions/data-plane/data-plane-google-storage/src/main/java/org/eclipse/edc/connector/dataplane/gcp/storage/GcsDataSource.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.gcp.storage;
 
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
@@ -96,6 +97,18 @@ public class GcsDataSource implements DataSource {
         @Override
         public String name() {
             return blobName;
+        }
+
+        @Override
+        public long size() {
+            BlobId blobId = BlobId.of(bucketName, blobName);
+            Blob blob = storageClient.get(blobId);
+            if (blob != null) {
+                return blob.getSize();
+            }
+
+            // TODO handle error
+            return 0;
         }
 
         @Override


### PR DESCRIPTION
## GCS connector enhancements

- Added class org.eclipse.edc.connector.provision.gcp.GcsProvisionerStatusChecker : used to verify if the transfer is completed, by checking the presence of ".complete" file in the bucket, works for consumer side only, since on provider side, the transfer process won't move past in progress in any case
- Class GcsDataSink updated with method 'complete', to write the file needed to check the transfer status
- Class GcsDataSource updated with method 'size', to return blob size
- Class StorageService/Impl provides 'list' method to return list of blobs in the bucket, used to check the transfer status
- Class GcsProvisioner updated to check if data address and service account key name/value are available in the resource definition: if not available use default settings and create service account for the transfer; TODO avoid leaking the newly created service account


