### PR TITLE
chore(gcp enhancement): optimise params and header

### DIFF
--- a/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpServiceAccountCredentials.java
+++ b/extensions/common/gcp/gcp-core/src/main/java/org/eclipse/edc/gcp/common/GcpServiceAccountCredentials.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
 package org.eclipse.edc.gcp.common;
 
 public class GcpServiceAccountCredentials {
@@ -6,9 +20,9 @@ public class GcpServiceAccountCredentials {
     private String serviceAccountValue;
 
     /**
-     * @param vaultTokenKeyName:          Key name of an entry in the vault containing an access token
-     * @param vaultServiceAccountKeyName: key name of an entry in the vault containing a valid Google Credentials file in json format
-     * @param serviceAccountValue:        Content of a valid Google Credentials file in json format encoded with base64
+     * @param vaultTokenKeyName Key name of an entry in the vault containing an access token
+     * @param vaultServiceAccountKeyName key name of an entry in the vault containing a valid Google Credentials file in json format
+     * @param serviceAccountValue Content of a valid Google Credentials file in json format encoded with base64
      */
     public GcpServiceAccountCredentials(String vaultTokenKeyName, String vaultServiceAccountKeyName, String serviceAccountValue) {
         this.vaultTokenKeyName = vaultTokenKeyName;


### PR DESCRIPTION
## What this PR changes/adds

Added Header for the GcpServiceAccountCredentials.java  
Optimised @params  

## Why it does that

EDC build needs every java class to have a header that says about the contributors  

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
