### PR TITLE
feat: update PolicyDefinition

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventListener.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionListener;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionCreated;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionDeleted;
+import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionUpdated;
 
 import java.time.Clock;
 
@@ -47,6 +48,16 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
     @Override
     public void deleted(PolicyDefinition policyDefinition) {
         var event = PolicyDefinitionDeleted.Builder.newInstance()
+                .policyDefinitionId(policyDefinition.getUid())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void updated(PolicyDefinition policyDefinition) {
+        var event = PolicyDefinitionUpdated.Builder.newInstance()
                 .policyDefinitionId(policyDefinition.getUid())
                 .at(clock.millis())
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -131,7 +131,7 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
 
         return transactionContext.execute(() -> {
             if (policyStore.findById(policyId) == null) {
-                return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyDefinition.getUid()));
+                return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyId));
             } else {
                 PolicyDefinition updatedPolicyDefinition = PolicyDefinition.Builder.newInstance()
                         .policy(policyDefinition.getPolicy())

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -125,6 +125,25 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
         });
     }
 
+
+    @Override
+    public @NotNull ServiceResult<Void> update(String policyId, PolicyDefinition policyDefinition) {
+
+        return transactionContext.execute(() -> {
+            if (policyStore.findById(policyId) == null) {
+                return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyDefinition.getUid()));
+            } else {
+                PolicyDefinition updatedPolicyDefinition = PolicyDefinition.Builder.newInstance()
+                        .policy(policyDefinition.getPolicy())
+                        .id(policyId)
+                        .build(); // to make sure policyDefinition does not have a random ID
+                policyStore.update(policyId, updatedPolicyDefinition);
+                observable.invokeForEach(l -> l.updated(updatedPolicyDefinition));
+                return ServiceResult.success(null);
+            }
+        });
+    }
+
     private Map<Class<?>, List<Class<?>>> getSubtypeMap() {
         return Map.of(
                 Constraint.class, List.of(MultiplicityConstraint.class, AtomicConstraint.class),

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionCreated;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionDeleted;
+import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionUpdated;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,11 +50,13 @@ public class PolicyDefinitionEventDispatchTest {
     }
 
     @Test
-    void shouldDispatchEventOnPolicyDefinitionCreationAndDeletion(PolicyDefinitionService service, EventRouter eventRouter) throws InterruptedException {
+    void shouldDispatchEventOnPolicyDefinitionCreationAndDeletionAndUpdate(PolicyDefinitionService service, EventRouter eventRouter) throws InterruptedException {
 
         doAnswer(i -> null).when(eventSubscriber).on(isA(PolicyDefinitionCreated.class));
 
         doAnswer(i -> null).when(eventSubscriber).on(isA(PolicyDefinitionDeleted.class));
+
+        doAnswer(i -> null).when(eventSubscriber).on(isA(PolicyDefinitionUpdated.class));
 
         eventRouter.register(eventSubscriber);
         var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
@@ -67,6 +70,11 @@ public class PolicyDefinitionEventDispatchTest {
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(isA(PolicyDefinitionDeleted.class));
 
+        });
+
+        service.update(policyDefinition.getUid(), policyDefinition);
+        await().untilAsserted(() -> {
+            verify(eventSubscriber).on(isA(PolicyDefinitionUpdated.class));
         });
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -19,10 +19,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionObservable;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
-import org.eclipse.edc.policy.model.Action;
-import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -37,8 +34,14 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 class PolicyDefinitionServiceImplTest {
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -19,7 +19,10 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionObservable;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.policy.model.Action;
+import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -34,19 +37,17 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class PolicyDefinitionServiceImplTest {
 
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final ContractDefinitionStore contractDefinitionStore = mock(ContractDefinitionStore.class);
     private final TransactionContext dummyTransactionContext = new NoopTransactionContext();
+    private final PolicyDefinitionObservable observable = mock(PolicyDefinitionObservable.class);
+    private final PolicyDefinitionServiceImpl policyServiceImpl = new PolicyDefinitionServiceImpl(dummyTransactionContext, policyStore, contractDefinitionStore, observable);
 
-    private final PolicyDefinitionServiceImpl policyServiceImpl = new PolicyDefinitionServiceImpl(dummyTransactionContext, policyStore, contractDefinitionStore, mock(PolicyDefinitionObservable.class));
 
     @Test
     void findById_shouldRelyOnPolicyStore() {
@@ -180,6 +181,39 @@ class PolicyDefinitionServiceImplTest {
                 qs.getFilterExpression().get(0).getOperandLeft().equals("contractPolicyId")));
     }
 
+    @Test
+    void updatePolicy_ifPolicyNotExists() {
+        var policy = createPolicy("policyId");
+        var updated = policyServiceImpl.update(policy.getUid(), policy);
+        assertThat(updated.succeeded()).isTrue();
+        assertThat(updated.getContent()).isEqualTo(policy);
+    }
+    @Test
+    void updatePolicy_shouldUpdateWhenExists() {
+        var policyId = "policyId";
+        var policy = createPolicy(policyId);
+        when(policyStore.findById(anyString())).thenReturn(policy);
+
+        var updated = policyServiceImpl.update(policyId, policy);
+
+        assertThat(updated.succeeded()).isTrue();
+        verify(policyStore).save(eq(policy));
+        verify(observable).invokeForEach(any());
+    }
+
+    @Test
+    void updatePolicy_shouldReturnNotFound_whenNotExists() {
+        var policyId = "policyId";
+        var policy = createPolicy(policyId);
+        when(policyStore.findById(anyString())).thenReturn(null);
+
+        var updated = policyServiceImpl.update(policyId, policy);
+
+        assertThat(updated.failed()).isTrue();
+        assertThat(updated.reason()).isEqualTo(NOT_FOUND);
+        verify(policyStore, never()).save(eq(policy));
+        verify(observable, never()).invokeForEach(any());
+    }
 
     @NotNull
     private Predicate<PolicyDefinition> hasId(String policyId) {

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -78,7 +78,7 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
             }
             return policiesById.get(policyId);
         } catch (Exception e) {
-            throw new EdcPersistenceException("Saving policy failed", e);
+            throw new EdcPersistenceException("Updating policy failed", e);
         }
     }
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -62,6 +63,20 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
     public void save(PolicyDefinition policy) {
         try {
             lockManager.writeLock(() -> policiesById.put(policy.getUid(), policy));
+        } catch (Exception e) {
+            throw new EdcPersistenceException("Saving policy failed", e);
+        }
+    }
+
+    @Override
+    public PolicyDefinition update(String policyId, PolicyDefinition policy) {
+        try {
+            Objects.requireNonNull(policyId, "policyId");
+            Objects.requireNonNull(policy, "policy");
+            if (policiesById.containsKey(policyId)) {
+                lockManager.writeLock(() -> policiesById.put(policyId, policy));
+            }
+            return policiesById.get(policyId);
         } catch (Exception e) {
             throw new EdcPersistenceException("Saving policy failed", e);
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
@@ -22,10 +22,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionResponseDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.List;
@@ -90,4 +92,15 @@ public interface PolicyDefinitionApi {
     )
     void deletePolicy(String id);
 
+    @Operation(description = "Updates an existing Policy, If the Policy is not found, no further action is taken",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "policy definition was updated successfully. Returns the Policy Definition Id and updated timestamp",
+                            content = @Content(schema = @Schema(implementation = Response.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "policy definition could not be updated, because it does not exists",
+                            content = @Content(schema = @Schema(implementation = Response.class)))
+                     }
+    )
+    void updatePolicy(String policyId, PolicyDefinitionUpdateDto policy);
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -30,6 +31,7 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionResponseDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.policy.model.Policy;
@@ -107,6 +109,19 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
                 .createdAt(resultContent.getCreatedAt())
                 .build();
 
+    }
+
+    @PUT
+    @Path("{policyId}")
+    @Override
+    public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updateDto) {
+        var transformResult = transformerRegistry.transform(updateDto, PolicyDefinition.class);
+        if (transformResult.failed()) {
+            throw new InvalidRequestException(transformResult.getFailureMessages());
+        }
+
+        policyDefinitionService.update(policyId, transformResult.getContent()).orElseThrow(exceptionMapper(PolicyDefinition.class, policyId));
+        monitor.debug(format("Policy definition updated %s", policyId));
     }
 
     @DELETE

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -114,8 +114,8 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
     @PUT
     @Path("{policyId}")
     @Override
-    public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updateDto) {
-        var transformResult = transformerRegistry.transform(updateDto, PolicyDefinition.class);
+    public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updatedPolicyDefinition) {
+        var transformResult = transformerRegistry.transform(updatedPolicyDefinition, PolicyDefinition.class);
         if (transformResult.failed()) {
             throw new InvalidRequestException(transformResult.getFailureMessages());
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionRequestDtoToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionToPolicyDefinitionResponseDtoTransformer;
+import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -51,6 +52,7 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         transformerRegistry.register(new PolicyDefinitionRequestDtoToPolicyDefinitionTransformer());
         transformerRegistry.register(new PolicyDefinitionToPolicyDefinitionResponseDtoTransformer());
+        transformerRegistry.register(new PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer());
 
         var monitor = context.getMonitor();
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionDto.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.policy.model.Policy;
+
+public abstract class PolicyDefinitionDto {
+
+    @NotNull
+    protected Policy policy;
+
+    protected abstract static class Builder<A extends PolicyDefinitionDto, B extends Builder<A, B>> {
+
+        protected final A dto;
+
+        protected Builder(A dto) {
+            this.dto = dto;
+        }
+
+        public B policy(Policy policy) {
+            dto.policy = policy;
+            return self();
+        }
+
+        public abstract B self();
+
+        public A build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDto.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.policy.model.Policy;
 import java.util.Objects;
 
 @JsonDeserialize(builder = PolicyDefinitionRequestDto.Builder.class)
-public class PolicyDefinitionRequestDto {
+public class PolicyDefinitionRequestDto extends PolicyDefinitionDto{
 
     private String id;
     @NotNull
@@ -58,17 +58,15 @@ public class PolicyDefinitionRequestDto {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder {
-
-        private final PolicyDefinitionRequestDto dto = new PolicyDefinitionRequestDto();
+    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionRequestDto, PolicyDefinitionRequestDto.Builder>{
 
         private Builder() {
-
+            super(new PolicyDefinitionRequestDto());
         }
 
         @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
+        public static PolicyDefinitionRequestDto.Builder newInstance() {
+            return new PolicyDefinitionRequestDto.Builder();
         }
 
         public Builder id(String id) {
@@ -81,6 +79,10 @@ public class PolicyDefinitionRequestDto {
             return this;
         }
 
+        @Override
+        public PolicyDefinitionRequestDto.Builder self() {
+            return this;
+        }
         public PolicyDefinitionRequestDto build() {
             return dto;
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.policy.model.Policy;
+
+@JsonDeserialize(builder = PolicyDefinitionUpdateDto.Builder.class)
+public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto{
+
+    @NotNull
+    private Policy policy;
+
+    private PolicyDefinitionUpdateDto() {
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionUpdateDto, Builder>{
+
+        private Builder() {
+            super(new PolicyDefinitionUpdateDto());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public PolicyDefinitionUpdateDto.Builder policy(Policy policy) {
+            dto.policy = policy;
+            return this;
+        }
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        public PolicyDefinitionUpdateDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.transform;
+
+import org.eclipse.edc.api.transformer.DtoTransformer;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer implements DtoTransformer<PolicyDefinitionUpdateDto, PolicyDefinition> {
+
+    @Override
+    public Class<PolicyDefinitionUpdateDto> getInputType() {
+        return PolicyDefinitionUpdateDto.class;
+    }
+
+    @Override
+    public Class<PolicyDefinition> getOutputType() {
+        return PolicyDefinition.class;
+    }
+
+    @Override
+    public @Nullable PolicyDefinition transform(@NotNull PolicyDefinitionUpdateDto object, @NotNull TransformerContext context) {
+        return PolicyDefinition.Builder.newInstance()
+                .policy(object.getPolicy())
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -173,6 +173,39 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     }
 
     @Test
+    void put_whenPolicyExists(PolicyDefinitionStore policyStore) {
+        var policy = createPolicy("policyDefId");
+        policyStore.save(policy);
+
+        policy.getPolicy().getExtensibleProperties().put("anotherKey", "anotherVal");
+
+        baseRequest()
+                .body(policy)
+                .contentType(JSON)
+                .put("/policydefinitions/policyDefId")
+                .then()
+                .statusCode(204);
+
+        var found = policyStore.findById("policyDefId");
+        assertThat(found).isNotNull();
+        assertThat(found.getPolicy().getExtensibleProperties()).containsEntry("anotherKey", "anotherVal");
+    }
+
+    @Test
+    void put_whenPolicyNotExists(PolicyDefinitionStore policyStore) {
+        var policy = createPolicy("policyId");
+
+        baseRequest()
+                .body(policy)
+                .contentType(JSON)
+                .put("/policydefinitions/policyId")
+                .then()
+                .statusCode(404);
+
+        assertThat(policyStore.findById("policyId")).isNull();
+    }
+
+    @Test
     void postPolicyId_alreadyExists(PolicyDefinitionStore policyStore) {
         policyStore.save(createPolicy("id"));
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.policy.model.Policy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyDefinitionRequestDtoValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingId() {
+        PolicyDefinition policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
+        var policy = PolicyDefinitionRequestDto.Builder.newInstance()
+                .policy(policyDefinition.getPolicy())
+                .id(null)
+                .build();
+
+        var result = validator.validate(policy);
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("must not be null"));
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingPolicy() {
+        var policy = PolicyDefinitionRequestDto.Builder.newInstance()
+                .id("id")
+                .policy(null)
+                .build();
+
+        var result = validator.validate(policy);
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("must not be null"));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
@@ -37,7 +37,7 @@ public class PolicyDefinitionRequestDtoValidationTest {
     }
 
     @Test
-    void verifyValidation_assetDto_missingId() {
+    void verifyValidation_policyDefinitionDto_missingId() {
         PolicyDefinition policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         var policy = PolicyDefinitionRequestDto.Builder.newInstance()
                 .policy(policyDefinition.getPolicy())
@@ -49,7 +49,7 @@ public class PolicyDefinitionRequestDtoValidationTest {
     }
 
     @Test
-    void verifyValidation_assetDto_missingPolicy() {
+    void verifyValidation_policyDefinitionDto_missingPolicy() {
         var policy = PolicyDefinitionRequestDto.Builder.newInstance()
                 .id("id")
                 .policy(null)

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.policy.model.Policy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyDefinitionUpdateDtoTest {
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+        var dto = PolicyDefinitionUpdateDto.Builder.newInstance()
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+
+        var str = objectMapper.writeValueAsString(dto);
+
+        assertThat(str).isNotNull();
+
+        var deserialized = objectMapper.readValue(str, PolicyDefinitionUpdateDto.class);
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(dto);
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyDefinitionUpdateDtoValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingPolicy() {
+        var policy = PolicyDefinitionUpdateDto.Builder.newInstance()
+                .policy(null)
+                .build();
+
+        var result = validator.validate(policy);
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("must not be null"));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
@@ -35,7 +35,7 @@ public class PolicyDefinitionUpdateDtoValidationTest {
     }
 
     @Test
-    void verifyValidation_assetDto_missingPolicy() {
+    void verifyValidation_policyDefinitionDto_missingPolicy() {
         var policy = PolicyDefinitionUpdateDto.Builder.newInstance()
                 .policy(null)
                 .build();

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.transform;
+
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest {
+
+    private final PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer transformer = new PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer();
+
+    @Test
+    void inputOutputType() {
+        assertThat(transformer.getInputType()).isNotNull();
+        assertThat(transformer.getOutputType()).isNotNull();
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var policyDefinitionDto = PolicyDefinitionUpdateDto.Builder.newInstance()
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+
+        var policyDefinition = transformer.transform(policyDefinitionDto, context);
+
+        assertThat(policyDefinition).isNotNull();
+        assertThat(policyDefinition.getPolicy()).isEqualTo(policyDefinitionDto.getPolicy());
+        assertThat(policyDefinition.getCreatedAt()).isNotEqualTo(0L); //should be set automatically
+    }
+
+}

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
@@ -103,6 +103,15 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
     }
 
     @Override
+    public PolicyDefinition update(String policyId, PolicyDefinition policy) {
+        Objects.requireNonNull(policy);
+        return transactionContext.execute(() -> {
+            update(policy);
+            return policy;
+        });
+    }
+
+    @Override
     public @Nullable PolicyDefinition deleteById(String policyId) {
         Objects.requireNonNull(policyId);
         return transactionContext.execute(() -> {

--- a/resources/openapi/yaml/management-api/policy-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/policy-definition-api.yaml
@@ -170,6 +170,48 @@ paths:
             \ by a contract definition"
       tags:
       - Policy
+  /policydefinitions/{policyId}:
+    put:
+      description: "Updates a policy definition with the given ID if it exists. If\
+        \ a policy definition is not found, no further action is taken\
+        \ DANGER ZONE: Note that updating policy definitions can have unexpected results,\
+        \ do this at your own risk!"
+      operationId: updatePolicy
+      parameters:
+      - in: path
+        name: policyId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyDefinitionUpdateDto'
+      responses:
+        "200":
+          description: Policy definition was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An policy definition with the given ID does not exist
+      tags:
+      - Policy
     get:
       description: Gets a policy definition with the given ID
       operationId: getPolicy
@@ -381,6 +423,14 @@ components:
         id:
           type: string
           example: null
+        policy:
+          $ref: '#/components/schemas/Policy'
+      required:
+      - policy
+    PolicyDefinitionUpdateDto:
+      type: object
+      example: null
+      properties:
         policy:
           $ref: '#/components/schemas/Policy'
       required:

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.spi.event.policydefinition;
+
+/**
+ * Describe a PolicyDefinition deletion, after this has emitted, the PolicyDefinition represented by the id won't be available anymore.
+ */
+public class PolicyDefinitionUpdated extends PolicyDefinitionEvent<PolicyDefinitionUpdated.Payload> {
+
+    private PolicyDefinitionUpdated() {
+    }
+
+    /**
+     * This class contains all event specific attributes of a PolicyDefinition Deletion Event
+     *
+     */
+    public static class Payload extends PolicyDefinitionEvent.Payload {
+    }
+
+    public static class Builder extends PolicyDefinitionEvent.Builder<PolicyDefinitionUpdated, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new PolicyDefinitionUpdated(), new Payload());
+        }
+    }
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.spi.event.policydefinition;
 
 /**
- * Describe a PolicyDefinition deletion, after this has emitted, the PolicyDefinition represented by the id won't be available anymore.
+ * Describe a PolicyDefinition update, after this has emitted, a PolicyDefinition with a certain id will be available/updated.
  */
 public class PolicyDefinitionUpdated extends PolicyDefinitionEvent<PolicyDefinitionUpdated.Payload> {
 
@@ -23,7 +23,7 @@ public class PolicyDefinitionUpdated extends PolicyDefinitionEvent<PolicyDefinit
     }
 
     /**
-     * This class contains all event specific attributes of a PolicyDefinition Deletion Event
+     * This class contains all event specific attributes of a PolicyDefinition Update Event
      *
      */
     public static class Payload extends PolicyDefinitionEvent.Payload {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/policydefinition/PolicyDefinitionService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/policydefinition/PolicyDefinitionService.java
@@ -64,4 +64,15 @@ public interface PolicyDefinitionService {
 
     @NotNull
     ServiceResult<PolicyDefinition> create(PolicyDefinition policy);
+
+    /**
+     * Updates a policy. If the policy does not yet exist, {@link ServiceResult#notFound(String)} will be returned.
+     *
+     * @param policyId the ID of the policy to update
+     * @param policy the contents of the policy.
+     *
+     * @return successful if updated, a failure otherwise.
+     */
+    @NotNull
+    ServiceResult<Void> update(String policyId, PolicyDefinition policy);
 }

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/observe/PolicyDefinitionListener.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/observe/PolicyDefinitionListener.java
@@ -42,4 +42,12 @@ public interface PolicyDefinitionListener {
 
     }
 
+    /**
+     * Called after a {@link PolicyDefinition} was updated.
+     *
+     * @param policyDefinition the policyDefinition that has been updated.
+     */
+    default void updated(PolicyDefinition policyDefinition) {
+
+    }
 }

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
@@ -56,6 +56,15 @@ public interface PolicyDefinitionStore {
     void save(PolicyDefinition policy);
 
     /**
+     * Updates the policy.
+     *
+     * @param policyId ID of the Policy to be updated
+     * @param policy to be updated.
+     * @throws EdcPersistenceException if something goes wrong.
+     */
+    PolicyDefinition update(String policyId, PolicyDefinition policy);
+
+    /**
      * Deletes a policy for the given id.
      *
      * @param policyId id of the policy to be removed.

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -90,6 +90,38 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .extracting(PolicyDefinition::getCreatedAt).isEqualTo(policy2.getCreatedAt());
     }
 
+
+
+    @Test
+    @DisplayName("Update Asset that does not yet exist")
+    void update_policyDoesNotExist() {
+        var id = getRandomId();
+        var policy = getPolicy(id, "target");
+
+        var updated = getPolicyDefinitionStore().update(id, policy);
+        assertThat(updated).isNull();
+    }
+
+    @Test
+    @DisplayName("Update an Asset that exists, adding a property")
+    void update_policyExists() {
+        var id = getRandomId();
+        var policy = getPolicy(id, "target");
+
+        getPolicyDefinitionStore().save(policy);
+
+        var newPolicy = createPolicy(id, "target2");
+        var result = getPolicyDefinitionStore().update(id, newPolicy);
+
+        var spec = QuerySpec.Builder.newInstance().build();
+        var policyFromDb = getPolicyDefinitionStore().findAll(spec);
+
+        Assertions.assertThat(policyFromDb).hasSize(1).first();
+        assertThat(result).isNotNull();
+        assertThat(result.getPolicy().getTarget()).isEqualTo("target2");
+        assertThat(result).isNotNull().usingRecursiveComparison().isEqualTo(newPolicy);
+    }
+
     @Test
     @DisplayName("Find policy by ID that exists")
     void findById_whenPresent() {
@@ -534,4 +566,15 @@ public abstract class PolicyDefinitionStoreTestBase {
     private String getRandomId() {
         return UUID.randomUUID().toString();
     }
+
+
+    private static PolicyDefinition getPolicy(String id, String target) {
+        return PolicyDefinition.Builder.newInstance()
+                .policy(Policy.Builder.newInstance()
+                        .target(target)
+                        .build())
+                .id(id)
+                .build();
+    }
+
 }

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -93,7 +93,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
 
     @Test
-    @DisplayName("Update Asset that does not yet exist")
+    @DisplayName("Update Policy that does not yet exist")
     void update_policyDoesNotExist() {
         var id = getRandomId();
         var policy = getPolicy(id, "target");
@@ -103,7 +103,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     }
 
     @Test
-    @DisplayName("Update an Asset that exists, adding a property")
+    @DisplayName("Update an Policy that exists, adding a property")
     void update_policyExists() {
         var id = getRandomId();
         var policy = getPolicy(id, "target");


### PR DESCRIPTION
## What this PR changes/adds

Adds the `UPDATE` endpoint to the `PolicyDefinitionApi`  

- Adds one `PUT` endpoint to the `PolicyDefinitionApiController`
- Adds new update() method to the `PolicyDefinitionStore`
- Adds implementations for `CosmosPolicyDefinitionStore`, `InMemoryPolicyDefinitionStore`, `SqlPolicyDefinitionStore`
- Adds tests for all the implementations


## Why it does that

To enable update semantics on PolicyDefinition.  

## Further notes

- Created `PolicyDefinitionUpdateDto`, to exclude the ID. The `policyId` is passed as path param. 
- Created `PolicyDefinitionDto` as a Parent Dto for `PolicyDefinitionUpdateDto` and `PolicyDefinitionUpdateDto`
- Updating Policy will fail if the Policy isn't found.  

## Linked Issue(s)

Closes #[2509](https://github.com/eclipse-edc/Connector/issues/2509)

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
