### PR TITLE
feat: update policy definition update

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventListener.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionListener;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionCreated;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionDeleted;
+import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionUpdated;
 
 import java.time.Clock;
 
@@ -47,6 +48,16 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
     @Override
     public void deleted(PolicyDefinition policyDefinition) {
         var event = PolicyDefinitionDeleted.Builder.newInstance()
+                .policyDefinitionId(policyDefinition.getUid())
+                .at(clock.millis())
+                .build();
+
+        eventRouter.publish(event);
+    }
+
+    @Override
+    public void updated(PolicyDefinition policyDefinition) {
+        var event = PolicyDefinitionUpdated.Builder.newInstance()
                 .policyDefinitionId(policyDefinition.getUid())
                 .at(clock.millis())
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -133,12 +133,8 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
             if (policyStore.findById(policyId) == null) {
                 return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyId));
             } else {
-                PolicyDefinition updatedPolicyDefinition = PolicyDefinition.Builder.newInstance()
-                        .policy(policyDefinition.getPolicy())
-                        .id(policyId)
-                        .build(); // to make sure policyDefinition does not have a random ID
-                policyStore.update(policyId, updatedPolicyDefinition);
-                observable.invokeForEach(l -> l.updated(updatedPolicyDefinition));
+                var updatedPolicy = policyStore.update(policyId, policyDefinition);
+                observable.invokeForEach(l -> l.updated(updatedPolicy));
                 return ServiceResult.success(null);
             }
         });

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -133,7 +133,11 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
             if (policyStore.findById(policyId) == null) {
                 return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyId));
             } else {
-                var updatedPolicy = policyStore.update(policyId, policyDefinition);
+                PolicyDefinition updatedPolicyDefinition = PolicyDefinition.Builder.newInstance()
+                        .policy(policyDefinition.getPolicy())
+                        .id(policyId)
+                        .build(); // to make sure policyDefinition does not have a random ID but the correct policyId
+                var updatedPolicy = policyStore.update(policyId, updatedPolicyDefinition);
                 observable.invokeForEach(l -> l.updated(updatedPolicy));
                 return ServiceResult.success(null);
             }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -131,7 +131,7 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
 
         return transactionContext.execute(() -> {
             if (policyStore.findById(policyId) == null) {
-                return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyDefinition.getUid()));
+                return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyId));
             } else {
                 PolicyDefinition updatedPolicyDefinition = PolicyDefinition.Builder.newInstance()
                         .policy(policyDefinition.getPolicy())

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImpl.java
@@ -125,6 +125,25 @@ public class PolicyDefinitionServiceImpl implements PolicyDefinitionService {
         });
     }
 
+
+    @Override
+    public @NotNull ServiceResult<Void> update(String policyId, PolicyDefinition policyDefinition) {
+
+        return transactionContext.execute(() -> {
+            if (policyStore.findById(policyId) == null) {
+                return ServiceResult.notFound(format("PolicyDefinition %s cannot be updated because it does not exists", policyDefinition.getUid()));
+            } else {
+                PolicyDefinition updatedPolicyDefinition = PolicyDefinition.Builder.newInstance()
+                        .policy(policyDefinition.getPolicy())
+                        .id(policyId)
+                        .build(); // to make sure policyDefinition does not have a random ID
+                policyStore.update(policyId, updatedPolicyDefinition);
+                observable.invokeForEach(l -> l.updated(updatedPolicyDefinition));
+                return ServiceResult.success(null);
+            }
+        });
+    }
+
     private Map<Class<?>, List<Class<?>>> getSubtypeMap() {
         return Map.of(
                 Constraint.class, List.of(MultiplicityConstraint.class, AtomicConstraint.class),

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionCreated;
 import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionDeleted;
+import org.eclipse.edc.spi.event.policydefinition.PolicyDefinitionUpdated;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,11 +50,13 @@ public class PolicyDefinitionEventDispatchTest {
     }
 
     @Test
-    void shouldDispatchEventOnPolicyDefinitionCreationAndDeletion(PolicyDefinitionService service, EventRouter eventRouter) throws InterruptedException {
+    void shouldDispatchEventOnPolicyDefinitionCreationAndDeletionAndUpdate(PolicyDefinitionService service, EventRouter eventRouter) throws InterruptedException {
 
         doAnswer(i -> null).when(eventSubscriber).on(isA(PolicyDefinitionCreated.class));
 
         doAnswer(i -> null).when(eventSubscriber).on(isA(PolicyDefinitionDeleted.class));
+
+        doAnswer(i -> null).when(eventSubscriber).on(isA(PolicyDefinitionUpdated.class));
 
         eventRouter.register(eventSubscriber);
         var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
@@ -67,6 +70,11 @@ public class PolicyDefinitionEventDispatchTest {
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(isA(PolicyDefinitionDeleted.class));
 
+        });
+
+        service.update(policyDefinition.getUid(), policyDefinition);
+        await().untilAsserted(() -> {
+            verify(eventSubscriber).on(isA(PolicyDefinitionUpdated.class));
         });
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -66,15 +66,15 @@ public class PolicyDefinitionEventDispatchTest {
             verify(eventSubscriber).on(isA(PolicyDefinitionCreated.class));
         });
 
+        service.update(policyDefinition.getUid(), policyDefinition);
+        await().untilAsserted(() -> {
+            verify(eventSubscriber).on(isA(PolicyDefinitionUpdated.class));
+        });
+
         service.deleteById(policyDefinition.getUid());
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(isA(PolicyDefinitionDeleted.class));
 
-        });
-
-        service.update(policyDefinition.getUid(), policyDefinition);
-        await().untilAsserted(() -> {
-            verify(eventSubscriber).on(isA(PolicyDefinitionUpdated.class));
         });
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class PolicyDefinitionServiceImplTest {
 
@@ -216,6 +218,20 @@ class PolicyDefinitionServiceImplTest {
         assertThat(updated.reason()).isEqualTo(NOT_FOUND);
         verify(policyStore, never()).save(eq(policy));
         verify(observable, never()).invokeForEach(any());
+    }
+
+    @Test
+    void updatePolicy_shouldReturnBadRequest_whenPolicyIdWrong() {
+        var policyId = "policyId";
+        var policy = createPolicy(policyId);
+        when(policyStore.findById(anyString())).thenReturn(policy);
+
+        var updated = policyServiceImpl.update("another-id", policy);
+
+        assertThat(updated.failed()).isTrue();
+        assertThat(updated.reason()).isEqualTo(BAD_REQUEST);
+        verifyNoInteractions(policyStore);
+        verifyNoInteractions(observable);
     }
 
     @NotNull

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -188,8 +188,8 @@ class PolicyDefinitionServiceImplTest {
     void updatePolicy_ifPolicyNotExists() {
         var policy = createPolicy("policyId");
         var updated = policyServiceImpl.update(policy.getUid(), policy);
-        assertThat(updated.succeeded()).isTrue();
-        assertThat(updated.getContent()).isEqualTo(policy);
+        assertThat(updated.succeeded()).isFalse();
+        assertThat(updated.getContent()).isNull();
     }
     @Test
     void updatePolicy_shouldUpdateWhenExists() {
@@ -200,7 +200,7 @@ class PolicyDefinitionServiceImplTest {
         var updated = policyServiceImpl.update(policyId, policy);
 
         assertThat(updated.succeeded()).isTrue();
-        verify(policyStore).save(eq(policy));
+        verify(policyStore).update(eq(policyId), eq(policy));
         verify(observable).invokeForEach(any());
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -19,10 +19,7 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionObservable;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
-import org.eclipse.edc.policy.model.Action;
-import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -37,8 +34,14 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 class PolicyDefinitionServiceImplTest {
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -19,7 +19,10 @@ import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.policy.spi.observe.PolicyDefinitionObservable;
 import org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.policy.model.Action;
+import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.service.spi.result.ServiceResult;
 import org.eclipse.edc.spi.asset.AssetSelectorExpression;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
@@ -34,19 +37,17 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class PolicyDefinitionServiceImplTest {
 
     private final PolicyDefinitionStore policyStore = mock(PolicyDefinitionStore.class);
     private final ContractDefinitionStore contractDefinitionStore = mock(ContractDefinitionStore.class);
     private final TransactionContext dummyTransactionContext = new NoopTransactionContext();
+    private final PolicyDefinitionObservable observable = mock(PolicyDefinitionObservable.class);
+    private final PolicyDefinitionServiceImpl policyServiceImpl = new PolicyDefinitionServiceImpl(dummyTransactionContext, policyStore, contractDefinitionStore, observable);
 
-    private final PolicyDefinitionServiceImpl policyServiceImpl = new PolicyDefinitionServiceImpl(dummyTransactionContext, policyStore, contractDefinitionStore, mock(PolicyDefinitionObservable.class));
 
     @Test
     void findById_shouldRelyOnPolicyStore() {
@@ -180,6 +181,39 @@ class PolicyDefinitionServiceImplTest {
                 qs.getFilterExpression().get(0).getOperandLeft().equals("contractPolicyId")));
     }
 
+    @Test
+    void updatePolicy_ifPolicyNotExists() {
+        var policy = createPolicy("policyId");
+        var updated = policyServiceImpl.update(policy.getUid(), policy);
+        assertThat(updated.succeeded()).isTrue();
+        assertThat(updated.getContent()).isEqualTo(policy);
+    }
+    @Test
+    void updatePolicy_shouldUpdateWhenExists() {
+        var policyId = "policyId";
+        var policy = createPolicy(policyId);
+        when(policyStore.findById(anyString())).thenReturn(policy);
+
+        var updated = policyServiceImpl.update(policyId, policy);
+
+        assertThat(updated.succeeded()).isTrue();
+        verify(policyStore).save(eq(policy));
+        verify(observable).invokeForEach(any());
+    }
+
+    @Test
+    void updatePolicy_shouldReturnNotFound_whenNotExists() {
+        var policyId = "policyId";
+        var policy = createPolicy(policyId);
+        when(policyStore.findById(anyString())).thenReturn(null);
+
+        var updated = policyServiceImpl.update(policyId, policy);
+
+        assertThat(updated.failed()).isTrue();
+        assertThat(updated.reason()).isEqualTo(NOT_FOUND);
+        verify(policyStore, never()).save(eq(policy));
+        verify(observable, never()).invokeForEach(any());
+    }
 
     @NotNull
     private Predicate<PolicyDefinition> hasId(String policyId) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/service/policydefinition/PolicyDefinitionServiceImplTest.java
@@ -36,14 +36,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.service.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class PolicyDefinitionServiceImplTest {
 
@@ -193,6 +193,7 @@ class PolicyDefinitionServiceImplTest {
         assertThat(updated.succeeded()).isFalse();
         assertThat(updated.getContent()).isNull();
     }
+
     @Test
     void updatePolicy_shouldUpdateWhenExists() {
         var policyId = "policyId";

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -78,7 +78,7 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
             }
             return policiesById.get(policyId);
         } catch (Exception e) {
-            throw new EdcPersistenceException("Saving policy failed", e);
+            throw new EdcPersistenceException("Updating policy failed", e);
         }
     }
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -62,6 +63,20 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
     public void save(PolicyDefinition policy) {
         try {
             lockManager.writeLock(() -> policiesById.put(policy.getUid(), policy));
+        } catch (Exception e) {
+            throw new EdcPersistenceException("Saving policy failed", e);
+        }
+    }
+
+    @Override
+    public PolicyDefinition update(String policyId, PolicyDefinition policy) {
+        try {
+            Objects.requireNonNull(policyId, "policyId");
+            Objects.requireNonNull(policy, "policy");
+            if (policiesById.containsKey(policyId)) {
+                lockManager.writeLock(() -> policiesById.put(policyId, policy));
+            }
+            return policiesById.get(policyId);
         } catch (Exception e) {
             throw new EdcPersistenceException("Saving policy failed", e);
         }

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/defaults/storage/policydefinition/InMemoryPolicyDefinitionStore.java
@@ -75,8 +75,9 @@ public class InMemoryPolicyDefinitionStore implements PolicyDefinitionStore {
             Objects.requireNonNull(policy, "policy");
             if (policiesById.containsKey(policyId)) {
                 lockManager.writeLock(() -> policiesById.put(policyId, policy));
+                return policy;
             }
-            return policiesById.get(policyId);
+            return null;
         } catch (Exception e) {
             throw new EdcPersistenceException("Updating policy failed", e);
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
@@ -100,7 +100,7 @@ public interface PolicyDefinitionApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
                     @ApiResponse(responseCode = "404", description = "policy definition could not be updated, because it does not exists",
                             content = @Content(schema = @Schema(implementation = Response.class)))
-                     }
+            }
     )
     void updatePolicy(String policyId, PolicyDefinitionUpdateDto policy);
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApi.java
@@ -22,10 +22,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.api.model.IdResponseDto;
 import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionResponseDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.List;
@@ -90,4 +92,15 @@ public interface PolicyDefinitionApi {
     )
     void deletePolicy(String id);
 
+    @Operation(description = "Updates an existing Policy, If the Policy is not found, no further action is taken",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "policy definition was updated successfully. Returns the Policy Definition Id and updated timestamp",
+                            content = @Content(schema = @Schema(implementation = Response.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)))),
+                    @ApiResponse(responseCode = "404", description = "policy definition could not be updated, because it does not exists",
+                            content = @Content(schema = @Schema(implementation = Response.class)))
+                     }
+    )
+    void updatePolicy(String policyId, PolicyDefinitionUpdateDto policy);
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -30,6 +31,7 @@ import org.eclipse.edc.api.query.QuerySpecDto;
 import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionResponseDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.policy.model.Policy;
@@ -107,6 +109,19 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
                 .createdAt(resultContent.getCreatedAt())
                 .build();
 
+    }
+
+    @PUT
+    @Path("{policyId}")
+    @Override
+    public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updateDto) {
+        var transformResult = transformerRegistry.transform(updateDto, PolicyDefinition.class);
+        if (transformResult.failed()) {
+            throw new InvalidRequestException(transformResult.getFailureMessages());
+        }
+
+        policyDefinitionService.update(policyId, transformResult.getContent()).orElseThrow(exceptionMapper(PolicyDefinition.class, policyId));
+        monitor.debug(format("Policy definition updated %s", policyId));
     }
 
     @DELETE

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionResponseDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateWrapperDto;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.policy.model.Policy;
@@ -115,7 +116,11 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
     @Path("{policyId}")
     @Override
     public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updatedPolicyDefinition) {
-        var transformResult = transformerRegistry.transform(updatedPolicyDefinition, PolicyDefinition.class);
+        PolicyDefinitionUpdateWrapperDto wrapper = PolicyDefinitionUpdateWrapperDto.Builder.newInstance()
+                .policyId(policyId)
+                .updateRequest(updatedPolicyDefinition)
+                .build();
+        var transformResult = transformerRegistry.transform(wrapper, PolicyDefinition.class);
         if (transformResult.failed()) {
             throw new InvalidRequestException(transformResult.getFailureMessages());
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiController.java
@@ -114,8 +114,8 @@ public class PolicyDefinitionApiController implements PolicyDefinitionApi {
     @PUT
     @Path("{policyId}")
     @Override
-    public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updateDto) {
-        var transformResult = transformerRegistry.transform(updateDto, PolicyDefinition.class);
+    public void updatePolicy(@PathParam("policyId") String policyId, PolicyDefinitionUpdateDto updatedPolicyDefinition) {
+        var transformResult = transformerRegistry.transform(updatedPolicyDefinition, PolicyDefinition.class);
         if (transformResult.failed()) {
             throw new InvalidRequestException(transformResult.getFailureMessages());
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionRequestDtoToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionToPolicyDefinitionResponseDtoTransformer;
-import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer;
+import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -52,7 +52,7 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         transformerRegistry.register(new PolicyDefinitionRequestDtoToPolicyDefinitionTransformer());
         transformerRegistry.register(new PolicyDefinitionToPolicyDefinitionResponseDtoTransformer());
-        transformerRegistry.register(new PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer());
+        transformerRegistry.register(new PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer());
 
         var monitor = context.getMonitor();
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionRequestDtoToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionToPolicyDefinitionResponseDtoTransformer;
+import org.eclipse.edc.connector.api.management.policy.transform.PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -51,6 +52,7 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         transformerRegistry.register(new PolicyDefinitionRequestDtoToPolicyDefinitionTransformer());
         transformerRegistry.register(new PolicyDefinitionToPolicyDefinitionResponseDtoTransformer());
+        transformerRegistry.register(new PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer());
 
         var monitor = context.getMonitor();
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionDto.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionDto.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.policy.model.Policy;
+
+public abstract class PolicyDefinitionDto {
+
+    @NotNull
+    protected Policy policy;
+
+    protected abstract static class Builder<A extends PolicyDefinitionDto, B extends Builder<A, B>> {
+
+        protected final A dto;
+
+        protected Builder(A dto) {
+            this.dto = dto;
+        }
+
+        public B policy(Policy policy) {
+            dto.policy = policy;
+            return self();
+        }
+
+        public abstract B self();
+
+        public A build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDto.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.policy.model.Policy;
 import java.util.Objects;
 
 @JsonDeserialize(builder = PolicyDefinitionRequestDto.Builder.class)
-public class PolicyDefinitionRequestDto extends PolicyDefinitionDto{
+public class PolicyDefinitionRequestDto extends PolicyDefinitionDto {
 
     private String id;
     @NotNull
@@ -58,7 +58,7 @@ public class PolicyDefinitionRequestDto extends PolicyDefinitionDto{
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionRequestDto, PolicyDefinitionRequestDto.Builder>{
+    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionRequestDto, PolicyDefinitionRequestDto.Builder> {
 
         private Builder() {
             super(new PolicyDefinitionRequestDto());
@@ -83,6 +83,7 @@ public class PolicyDefinitionRequestDto extends PolicyDefinitionDto{
         public PolicyDefinitionRequestDto.Builder self() {
             return this;
         }
+
         public PolicyDefinitionRequestDto build() {
             return dto;
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDto.java
@@ -23,7 +23,7 @@ import org.eclipse.edc.policy.model.Policy;
 import java.util.Objects;
 
 @JsonDeserialize(builder = PolicyDefinitionRequestDto.Builder.class)
-public class PolicyDefinitionRequestDto {
+public class PolicyDefinitionRequestDto extends PolicyDefinitionDto{
 
     private String id;
     @NotNull
@@ -58,17 +58,15 @@ public class PolicyDefinitionRequestDto {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder {
-
-        private final PolicyDefinitionRequestDto dto = new PolicyDefinitionRequestDto();
+    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionRequestDto, PolicyDefinitionRequestDto.Builder>{
 
         private Builder() {
-
+            super(new PolicyDefinitionRequestDto());
         }
 
         @JsonCreator
-        public static Builder newInstance() {
-            return new Builder();
+        public static PolicyDefinitionRequestDto.Builder newInstance() {
+            return new PolicyDefinitionRequestDto.Builder();
         }
 
         public Builder id(String id) {
@@ -81,6 +79,10 @@ public class PolicyDefinitionRequestDto {
             return this;
         }
 
+        @Override
+        public PolicyDefinitionRequestDto.Builder self() {
+            return this;
+        }
         public PolicyDefinitionRequestDto build() {
             return dto;
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
@@ -21,7 +21,7 @@ import jakarta.validation.constraints.NotNull;
 import org.eclipse.edc.policy.model.Policy;
 
 @JsonDeserialize(builder = PolicyDefinitionUpdateDto.Builder.class)
-public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto{
+public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto {
 
     @NotNull
     private Policy policy;
@@ -34,7 +34,7 @@ public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto{
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionUpdateDto, Builder>{
+    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionUpdateDto, Builder> {
 
         private Builder() {
             super(new PolicyDefinitionUpdateDto());
@@ -49,6 +49,7 @@ public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto{
             dto.policy = policy;
             return this;
         }
+
         @Override
         public Builder self() {
             return this;

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.edc.policy.model.Policy;
+
+@JsonDeserialize(builder = PolicyDefinitionUpdateDto.Builder.class)
+public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto{
+
+    @NotNull
+    private Policy policy;
+
+    private PolicyDefinitionUpdateDto() {
+    }
+
+    public Policy getPolicy() {
+        return policy;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder extends PolicyDefinitionDto.Builder<PolicyDefinitionUpdateDto, Builder>{
+
+        private Builder() {
+            super(new PolicyDefinitionUpdateDto());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public PolicyDefinitionUpdateDto.Builder policy(Policy policy) {
+            dto.policy = policy;
+            return this;
+        }
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        public PolicyDefinitionUpdateDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDto.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -45,6 +45,7 @@ public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto {
             return new Builder();
         }
 
+        @Override
         public PolicyDefinitionUpdateDto.Builder policy(Policy policy) {
             dto.policy = policy;
             return this;
@@ -55,6 +56,7 @@ public class PolicyDefinitionUpdateDto extends PolicyDefinitionDto {
             return this;
         }
 
+        @Override
         public PolicyDefinitionUpdateDto build() {
             return dto;
         }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateWrapperDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateWrapperDto.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.api.management.policy.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(builder = PolicyDefinitionUpdateWrapperDto.Builder.class)
-public class PolicyDefinitionUpdateWrapperDto extends PolicyDefinitionDto {
+public class PolicyDefinitionUpdateWrapperDto {
 
     private PolicyDefinitionUpdateDto policyDefinitionUpdateDto;
     private String policyId;

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateWrapperDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateWrapperDto.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateWrapperDto.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateWrapperDto.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(builder = PolicyDefinitionUpdateWrapperDto.Builder.class)
+public class PolicyDefinitionUpdateWrapperDto extends PolicyDefinitionDto {
+
+    private PolicyDefinitionUpdateDto policyDefinitionUpdateDto;
+    private String policyId;
+
+    private PolicyDefinitionUpdateWrapperDto() {
+    }
+
+    public PolicyDefinitionUpdateDto getUpdateDto() {
+        return policyDefinitionUpdateDto;
+    }
+
+    public String getPolicyId() {
+        return policyId;
+    }
+
+    public static final class Builder {
+
+        private final PolicyDefinitionUpdateWrapperDto dto;
+
+        private Builder() {
+            dto = new PolicyDefinitionUpdateWrapperDto();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder updateRequest(PolicyDefinitionUpdateDto dto) {
+            this.dto.policyDefinitionUpdateDto = dto;
+            return this;
+        }
+
+        public Builder policyId(String policyId) {
+            this.dto.policyId = policyId;
+            return this;
+        }
+
+        public PolicyDefinitionUpdateWrapperDto build() {
+            return dto;
+        }
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.transform;
+
+import org.eclipse.edc.api.transformer.DtoTransformer;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer implements DtoTransformer<PolicyDefinitionUpdateDto, PolicyDefinition> {
+
+    @Override
+    public Class<PolicyDefinitionUpdateDto> getInputType() {
+        return PolicyDefinitionUpdateDto.class;
+    }
+
+    @Override
+    public Class<PolicyDefinition> getOutputType() {
+        return PolicyDefinition.class;
+    }
+
+    @Override
+    public @Nullable PolicyDefinition transform(@NotNull PolicyDefinitionUpdateDto object, @NotNull TransformerContext context) {
+        return PolicyDefinition.Builder.newInstance()
+                .policy(object.getPolicy())
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer.java
@@ -15,17 +15,17 @@
 package org.eclipse.edc.connector.api.management.policy.transform;
 
 import org.eclipse.edc.api.transformer.DtoTransformer;
-import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateWrapperDto;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer implements DtoTransformer<PolicyDefinitionUpdateDto, PolicyDefinition> {
+public class PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer implements DtoTransformer<PolicyDefinitionUpdateWrapperDto, PolicyDefinition> {
 
     @Override
-    public Class<PolicyDefinitionUpdateDto> getInputType() {
-        return PolicyDefinitionUpdateDto.class;
+    public Class<PolicyDefinitionUpdateWrapperDto> getInputType() {
+        return PolicyDefinitionUpdateWrapperDto.class;
     }
 
     @Override
@@ -34,9 +34,10 @@ public class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer implements D
     }
 
     @Override
-    public @Nullable PolicyDefinition transform(@NotNull PolicyDefinitionUpdateDto object, @NotNull TransformerContext context) {
+    public @Nullable PolicyDefinition transform(@NotNull PolicyDefinitionUpdateWrapperDto object, @NotNull TransformerContext context) {
         return PolicyDefinition.Builder.newInstance()
-                .policy(object.getPolicy())
+                .policy(object.getUpdateDto().getPolicy())
+                .id(object.getPolicyId())
                 .build();
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerIntegrationTest.java
@@ -173,6 +173,39 @@ public class PolicyDefinitionApiControllerIntegrationTest {
     }
 
     @Test
+    void put_whenPolicyExists(PolicyDefinitionStore policyStore) {
+        var policy = createPolicy("policyDefId");
+        policyStore.save(policy);
+
+        policy.getPolicy().getExtensibleProperties().put("anotherKey", "anotherVal");
+
+        baseRequest()
+                .body(policy)
+                .contentType(JSON)
+                .put("/policydefinitions/policyDefId")
+                .then()
+                .statusCode(204);
+
+        var found = policyStore.findById("policyDefId");
+        assertThat(found).isNotNull();
+        assertThat(found.getPolicy().getExtensibleProperties()).containsEntry("anotherKey", "anotherVal");
+    }
+
+    @Test
+    void put_whenPolicyNotExists(PolicyDefinitionStore policyStore) {
+        var policy = createPolicy("policyId");
+
+        baseRequest()
+                .body(policy)
+                .contentType(JSON)
+                .put("/policydefinitions/policyId")
+                .then()
+                .statusCode(404);
+
+        assertThat(policyStore.findById("policyId")).isNull();
+    }
+
+    @Test
     void postPolicyId_alreadyExists(PolicyDefinitionStore policyStore) {
         policyStore.save(createPolicy("id"));
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
@@ -39,7 +39,11 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/PolicyDefinitionApiControllerTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.api.transformer.DtoTransformerRegistry;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionRequestDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionResponseDto;
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateWrapperDto;
 import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.policy.model.Policy;
@@ -246,7 +247,7 @@ class PolicyDefinitionApiControllerTest {
     void updatePolicy_ifPolicyExists() {
         var dto = PolicyDefinitionUpdateDto.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         var policyDefinition = TestFunctions.createPolicy("id");
-        when(transformerRegistry.transform(isA(PolicyDefinitionUpdateDto.class), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
+        when(transformerRegistry.transform(isA(PolicyDefinitionUpdateWrapperDto.class), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
         when(service.update(anyString(), any())).thenReturn(ServiceResult.success(null));
         when(service.findById(anyString())).thenReturn(policyDefinition);
 
@@ -257,7 +258,7 @@ class PolicyDefinitionApiControllerTest {
     @Test
     void updatePolicy_transformationFails() {
         var dto = PolicyDefinitionUpdateDto.Builder.newInstance().build();
-        when(transformerRegistry.transform(isA(PolicyDefinitionUpdateDto.class), eq(PolicyDefinition.class))).thenReturn(Result.failure("failure"));
+        when(transformerRegistry.transform(isA(PolicyDefinitionUpdateWrapperDto.class), eq(PolicyDefinition.class))).thenReturn(Result.failure("failure"));
 
         assertThatThrownBy(() -> controller.updatePolicy("test-policy-id", dto)).isInstanceOf(InvalidRequestException.class);
     }
@@ -266,7 +267,7 @@ class PolicyDefinitionApiControllerTest {
     void updatePolicy_ifPolicyNotExists() {
         var dto = PolicyDefinitionUpdateDto.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         var policyDefinition = TestFunctions.createPolicy("id");
-        when(transformerRegistry.transform(isA(PolicyDefinitionUpdateDto.class), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
+        when(transformerRegistry.transform(isA(PolicyDefinitionUpdateWrapperDto.class), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
         when(service.update(anyString(), any())).thenReturn(ServiceResult.success(null));
 
         controller.updatePolicy("test-policy-id", dto);

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.eclipse.edc.connector.policy.spi.PolicyDefinition;
+import org.eclipse.edc.policy.model.Policy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyDefinitionRequestDtoValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingId() {
+        PolicyDefinition policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
+        var policy = PolicyDefinitionRequestDto.Builder.newInstance()
+                .policy(policyDefinition.getPolicy())
+                .id(null)
+                .build();
+
+        var result = validator.validate(policy);
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("must not be null"));
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingPolicy() {
+        var policy = PolicyDefinitionRequestDto.Builder.newInstance()
+                .id("id")
+                .policy(null)
+                .build();
+
+        var result = validator.validate(policy);
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("must not be null"));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
@@ -37,7 +37,7 @@ public class PolicyDefinitionRequestDtoValidationTest {
     }
 
     @Test
-    void verifyValidation_assetDto_missingId() {
+    void verifyValidation_policyDefinitionDto_missingId() {
         PolicyDefinition policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         var policy = PolicyDefinitionRequestDto.Builder.newInstance()
                 .policy(policyDefinition.getPolicy())
@@ -49,7 +49,7 @@ public class PolicyDefinitionRequestDtoValidationTest {
     }
 
     @Test
-    void verifyValidation_assetDto_missingPolicy() {
+    void verifyValidation_policyDefinitionDto_missingPolicy() {
         var policy = PolicyDefinitionRequestDto.Builder.newInstance()
                 .id("id")
                 .policy(null)

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionRequestDtoValidationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.policy.model.Policy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyDefinitionUpdateDtoTest {
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void verifySerialization() throws JsonProcessingException {
+        var dto = PolicyDefinitionUpdateDto.Builder.newInstance()
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+
+        var str = objectMapper.writeValueAsString(dto);
+
+        assertThat(str).isNotNull();
+
+        var deserialized = objectMapper.readValue(str, PolicyDefinitionUpdateDto.class);
+        assertThat(deserialized).usingRecursiveComparison().isEqualTo(dto);
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.model;
+
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PolicyDefinitionUpdateDtoValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    void verifyValidation_assetDto_missingPolicy() {
+        var policy = PolicyDefinitionUpdateDto.Builder.newInstance()
+                .policy(null)
+                .build();
+
+        var result = validator.validate(policy);
+        assertThat(result).anySatisfy(cv -> assertThat(cv.getMessage()).isEqualTo("must not be null"));
+    }
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/model/PolicyDefinitionUpdateDtoValidationTest.java
@@ -35,7 +35,7 @@ public class PolicyDefinitionUpdateDtoValidationTest {
     }
 
     @Test
-    void verifyValidation_assetDto_missingPolicy() {
+    void verifyValidation_policyDefinitionDto_missingPolicy() {
         var policy = PolicyDefinitionUpdateDto.Builder.newInstance()
                 .policy(null)
                 .build();

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.policy.transform;
+
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest {
+
+    private final PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer transformer = new PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer();
+
+    @Test
+    void inputOutputType() {
+        assertThat(transformer.getInputType()).isNotNull();
+        assertThat(transformer.getOutputType()).isNotNull();
+    }
+
+    @Test
+    void transform() {
+        var context = mock(TransformerContext.class);
+        var policyDefinitionDto = PolicyDefinitionUpdateDto.Builder.newInstance()
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+
+        var policyDefinition = transformer.transform(policyDefinitionDto, context);
+
+        assertThat(policyDefinition).isNotNull();
+        assertThat(policyDefinition.getPolicy()).isEqualTo(policyDefinitionDto.getPolicy());
+        assertThat(policyDefinition.getCreatedAt()).isNotEqualTo(0L); //should be set automatically
+    }
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.api.management.policy.transform;
 
 import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateDto;
+import org.eclipse.edc.connector.api.management.policy.model.PolicyDefinitionUpdateWrapperDto;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.Test;
@@ -22,9 +23,9 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest {
+class PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformerTest {
 
-    private final PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer transformer = new PolicyDefinitionUpdateDtoToPolicyDefinitionTransformer();
+    private final PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer transformer = new PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformer();
 
     @Test
     void inputOutputType() {
@@ -35,14 +36,15 @@ class PolicyDefinitionUpdateDtoToPolicyDefinitionTransformerTest {
     @Test
     void transform() {
         var context = mock(TransformerContext.class);
-        var policyDefinitionDto = PolicyDefinitionUpdateDto.Builder.newInstance()
-                .policy(Policy.Builder.newInstance().build())
+        var policyDefinitionDto = PolicyDefinitionUpdateWrapperDto.Builder.newInstance()
+                .updateRequest(PolicyDefinitionUpdateDto.Builder.newInstance()
+                        .policy(Policy.Builder.newInstance().build()).build())
                 .build();
 
         var policyDefinition = transformer.transform(policyDefinitionDto, context);
 
         assertThat(policyDefinition).isNotNull();
-        assertThat(policyDefinition.getPolicy()).isEqualTo(policyDefinitionDto.getPolicy());
+        assertThat(policyDefinition.getPolicy()).isEqualTo(policyDefinitionDto.getUpdateDto().getPolicy());
         assertThat(policyDefinition.getCreatedAt()).isNotEqualTo(0L); //should be set automatically
     }
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/api/management/policy/transform/PolicyDefinitionUpdateWrapperDtoToPolicyDefinitionTransformerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
@@ -103,6 +103,15 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
     }
 
     @Override
+    public PolicyDefinition update(String policyId, PolicyDefinition policy) {
+        Objects.requireNonNull(policy);
+        return transactionContext.execute(() -> {
+            update(policy);
+            return policy;
+        });
+    }
+
+    @Override
     public @Nullable PolicyDefinition deleteById(String policyId) {
         Objects.requireNonNull(policyId);
         return transactionContext.execute(() -> {

--- a/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
+++ b/extensions/control-plane/store/sql/policy-definition-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/policydefinition/store/SqlPolicyDefinitionStore.java
@@ -95,7 +95,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
         Objects.requireNonNull(policy);
         transactionContext.execute(() -> {
             if (findById(policy.getUid()) != null) {
-                update(policy);
+                update(policy, policy.getUid());
             } else {
                 insert(policy);
             }
@@ -103,11 +103,11 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
     }
 
     @Override
-    public PolicyDefinition update(String policyId, PolicyDefinition policy) {
-        Objects.requireNonNull(policy);
+    public PolicyDefinition update(String policyId, PolicyDefinition policyDefinition) {
+        Objects.requireNonNull(policyDefinition);
         return transactionContext.execute(() -> {
-            update(policy);
-            return policy;
+            update(policyDefinition, policyId);
+            return policyDefinition;
         });
     }
 
@@ -150,11 +150,10 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
         });
     }
 
-    private void update(PolicyDefinition def) {
+    private void update(PolicyDefinition def, String policyId) {
         transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 var policy = def.getPolicy();
-                var id = def.getUid();
                 executeQuery(connection, statements.getUpdateTemplate(),
                         toJson(policy.getPermissions(), permissionListType),
                         toJson(policy.getProhibitions(), prohibitionListType),
@@ -165,7 +164,7 @@ public class SqlPolicyDefinitionStore extends AbstractSqlStore implements Policy
                         policy.getAssignee(),
                         policy.getTarget(),
                         toJson(policy.getType(), policyType),
-                        id);
+                        policyId);
             } catch (Exception e) {
                 throw new EdcPersistenceException(e.getMessage(), e);
             }

--- a/resources/openapi/openapi.yaml
+++ b/resources/openapi/openapi.yaml
@@ -22,6 +22,511 @@ tags:
     \ path parameters and request body are supported (in the limits fixed by the HTTP\
     \ server) and can also conveyed to the actual data source."
 paths:
+  /assets:
+    get:
+      tags:
+      - Asset
+      description: Gets all assets according to a particular query
+      operationId: getAllAssets
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+    post:
+      tags:
+      - Asset
+      description: Creates a new asset together with a data address
+      operationId: createAsset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetEntryDto'
+      responses:
+        "200":
+          description: Asset was created successfully. Returns the asset Id and created
+            timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create asset, because an asset with that ID already\
+            \ exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/request:
+    post:
+      tags:
+      - Asset
+      description: ' all assets according to a particular query'
+      operationId: requestAssets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/{assetId}:
+    put:
+      tags:
+      - Asset
+      description: "Updates an asset with the given ID if it exists. If the asset\
+        \ is not found, no further action is taken. DANGER ZONE: Note that updating\
+        \ assets can have unexpected results, especially for contract offers that\
+        \ have been sent out or ongoing or contract negotiations."
+      operationId: updateAsset
+      parameters:
+      - name: assetId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetUpdateRequestDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: "Asset could not be updated, because it does not exist. Asset\
+            \ need to be created together with DataAddresses."
+  /assets/{assetId}/dataaddress:
+    put:
+      tags:
+      - Asset
+      description: "Updates a DataAddress for an asset with the given ID. If the asset\
+        \ is not found, no further action is taken"
+      operationId: updateDataAddress
+      parameters:
+      - name: assetId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataAddressDto'
+      responses:
+        "200":
+          description: Asset was updated successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/{id}:
+    get:
+      tags:
+      - Asset
+      description: Gets an asset with the given ID
+      operationId: getAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The asset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetResponseDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Asset
+      description: "Removes an asset with the given ID if possible. Deleting an asset\
+        \ is only possible if that asset is not yet referenced by a contract agreement,\
+        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
+        \ can have unexpected results, especially for contract offers that have been\
+        \ sent out or ongoing or contract negotiations."
+      operationId: removeAsset
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Asset was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "The asset cannot be deleted, because it is referenced by a\
+            \ contract agreement"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /assets/{id}/address:
+    get:
+      tags:
+      - Asset
+      description: Gets a data address of an asset with the given ID
+      operationId: getAssetDataAddress
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The data address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataAddressDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An asset with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /callback/{processId}/deprovision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callDeprovisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeprovisionedResource'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /callback/{processId}/provision:
+    post:
+      tags:
+      - HTTP Provisioner Webhook
+      operationId: callProvisionWebhook
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProvisionerWebhookRequest'
+      responses:
+        default:
+          description: default response
+          content:
+            application/json: {}
+  /catalog:
+    get:
+      tags:
+      - Catalog
+      operationId: getCatalog
+      parameters:
+      - name: providerUrl
+        in: query
+        required: true
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        default:
+          description: Gets contract offers (=catalog) of a single connector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+      deprecated: true
+  /catalog/request:
+    post:
+      tags:
+      - Catalog
+      operationId: requestCatalog
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/CatalogRequestDto'
+        required: true
+      responses:
+        default:
+          description: Gets contract offers (=catalog) of a single connector
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+  /check/health:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: checkHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/liveness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a liveness probe to determine whether the runtime is working
+        properly.
+      operationId: getLiveness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/readiness:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a readiness probe to determine whether the runtime is
+        able to accept requests.
+      operationId: getReadiness
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
+  /check/startup:
+    get:
+      tags:
+      - Application Observability
+      description: Performs a startup probe to determine whether the runtime has completed
+        startup.
+      operationId: getStartup
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HealthStatus'
   /contractagreements:
     get:
       tags:
@@ -144,6 +649,242 @@ paths:
                   $ref: '#/components/schemas/ApiErrorDetail'
         "404":
           description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions:
+    get:
+      tags:
+      - Contract Definition
+      description: Returns all contract definitions according to a query
+      operationId: getAllContractDefinitions
+      parameters:
+      - name: offset
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: sort
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - ASC
+          - DESC
+      - name: sortField
+        in: query
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+      deprecated: true
+    post:
+      tags:
+      - Contract Definition
+      description: Creates a new contract definition
+      operationId: createContractDefinition
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionCreateDto'
+      responses:
+        "200":
+          description: contract definition was created successfully. Returns the Contract
+            Definition Id and created timestamp
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdResponseDto'
+        "400":
+          description: Request body was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "409":
+          description: "Could not create contract definition, because a contract definition\
+            \ with that ID already exists"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions/request:
+    post:
+      tags:
+      - Contract Definition
+      description: Returns all contract definitions according to a query
+      operationId: queryAllContractDefinitions
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/QuerySpecDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: Request was malformed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions/{contractDefinitionId}:
+    put:
+      tags:
+      - Contract Definition
+      description: Updated a contract definition with the given ID
+      operationId: updateContractDefinition
+      parameters:
+      - name: contractDefinitionId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/ContractDefinitionUpdateDto'
+      responses:
+        "204":
+          description: Contract definition was updated successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract definition with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+  /contractdefinitions/{id}:
+    get:
+      tags:
+      - Contract Definition
+      description: Gets an contract definition with the given ID
+      operationId: getContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The contract definition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractDefinitionResponseDto'
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: An contract agreement with the given ID does not exist
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+    delete:
+      tags:
+      - Contract Definition
+      description: "Removes a contract definition with the given ID if possible. DANGER\
+        \ ZONE: Note that deleting contract definitions can have unexpected results,\
+        \ especially for contract offers that have been sent out or ongoing or contract\
+        \ negotiations."
+      operationId: deleteContractDefinition
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Contract definition was deleted successfully
+        "400":
+          description: "Request was malformed, e.g. id was null"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+        "404":
+          description: A contract definition with the given ID does not exist
           content:
             application/json:
               schema:
@@ -468,52 +1209,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /callback/{processId}/deprovision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callDeprovisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeprovisionedResource'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
-  /callback/{processId}/provision:
-    post:
-      tags:
-      - HTTP Provisioner Webhook
-      operationId: callProvisionWebhook
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProvisionerWebhookRequest'
-      responses:
-        default:
-          description: default response
-          content:
-            application/json: {}
   /instances:
     get:
       tags:
@@ -767,425 +1462,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /check/health:
-    get:
+  /policydefinitions/{policyId}:
+    put:
       tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: checkHealth
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/liveness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a liveness probe to determine whether the runtime is working
-        properly.
-      operationId: getLiveness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/readiness:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a readiness probe to determine whether the runtime is
-        able to accept requests.
-      operationId: getReadiness
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /check/startup:
-    get:
-      tags:
-      - Application Observability
-      description: Performs a startup probe to determine whether the runtime has completed
-        startup.
-      operationId: getStartup
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HealthStatus'
-  /contractdefinitions:
-    get:
-      tags:
-      - Contract Definition
-      description: Returns all contract definitions according to a query
-      operationId: getAllContractDefinitions
+      - Policy
+      description: "Updates an existing Policy, If the Policy is not found, no further\
+        \ action is taken"
+      operationId: updatePolicy
       parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-    post:
-      tags:
-      - Contract Definition
-      description: Creates a new contract definition
-      operationId: createContractDefinition
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/ContractDefinitionRequestDto'
-      responses:
-        "200":
-          description: contract definition was created successfully. Returns the Contract
-            Definition Id and created timestamp
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IdResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create contract definition, because a contract definition\
-            \ with that ID already exists"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractdefinitions/request:
-    post:
-      tags:
-      - Contract Definition
-      description: Returns all contract definitions according to a query
-      operationId: queryAllContractDefinitions
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: Request was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /contractdefinitions/{id}:
-    get:
-      tags:
-      - Contract Definition
-      description: Gets an contract definition with the given ID
-      operationId: getContractDefinition
-      parameters:
-      - name: id
+      - name: policyId
         in: path
         required: true
         style: simple
         explode: false
         schema:
           type: string
-      responses:
-        "200":
-          description: The contract definition
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ContractDefinitionResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An contract agreement with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Contract Definition
-      description: "Removes a contract definition with the given ID if possible. DANGER\
-        \ ZONE: Note that deleting contract definitions can have unexpected results,\
-        \ especially for contract offers that have been sent out or ongoing or contract\
-        \ negotiations."
-      operationId: deleteContractDefinition
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Contract definition was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: A contract definition with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /catalog:
-    get:
-      tags:
-      - Catalog
-      operationId: getCatalog
-      parameters:
-      - name: providerUrl
-        in: query
-        required: true
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
-      deprecated: true
-  /catalog/request:
-    post:
-      tags:
-      - Catalog
-      operationId: requestCatalog
-      requestBody:
-        content:
-          '*/*':
-            schema:
-              $ref: '#/components/schemas/CatalogRequestDto'
-        required: true
-      responses:
-        default:
-          description: Gets contract offers (=catalog) of a single connector
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Catalog'
-  /assets:
-    get:
-      tags:
-      - Asset
-      description: Gets all assets according to a particular query
-      operationId: getAllAssets
-      parameters:
-      - name: offset
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: limit
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: integer
-          format: int32
-      - name: filter
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - ASC
-          - DESC
-      - name: sortField
-        in: query
-        required: false
-        style: form
-        explode: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-      deprecated: true
-    post:
-      tags:
-      - Asset
-      description: Creates a new asset together with a data address
-      operationId: createAsset
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetEntryDto'
+              $ref: '#/components/schemas/PolicyDefinitionUpdateDto'
       responses:
         "200":
-          description: Asset was created successfully. Returns the asset Id and created
-            timestamp
+          description: policy definition was updated successfully. Returns the Policy
+            Definition Id and updated timestamp
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IdResponseDto'
+                $ref: '#/components/schemas/Response'
         "400":
           description: Request body was malformed
           content:
@@ -1194,124 +1498,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "Could not create asset, because an asset with that ID already\
+        "404":
+          description: "policy definition could not be updated, because it does not\
             \ exists"
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /assets/request:
-    post:
-      tags:
-      - Asset
-      description: ' all assets according to a particular query'
-      operationId: requestAssets
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/QuerySpecDto'
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: Request body was malformed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-  /assets/{id}:
-    get:
-      tags:
-      - Asset
-      description: Gets an asset with the given ID
-      operationId: getAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: The asset
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetResponseDto'
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-    delete:
-      tags:
-      - Asset
-      description: "Removes an asset with the given ID if possible. Deleting an asset\
-        \ is only possible if that asset is not yet referenced by a contract agreement,\
-        \ in which case an error is returned. DANGER ZONE: Note that deleting assets\
-        \ can have unexpected results, especially for contract offers that have been\
-        \ sent out or ongoing or contract negotiations."
-      operationId: removeAsset
-      parameters:
-      - name: id
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Asset was deleted successfully
-        "400":
-          description: "Request was malformed, e.g. id was null"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "404":
-          description: An asset with the given ID does not exist
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-        "409":
-          description: "The asset cannot be deleted, because it is referenced by a\
-            \ contract agreement"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
+                $ref: '#/components/schemas/Response'
   /token:
     get:
       tags:
@@ -1335,6 +1528,40 @@ paths:
           description: Request was malformed
         "403":
           description: Token is invalid
+  /transfer:
+    post:
+      tags:
+      - Data Plane control API
+      description: Initiates a data transfer for the given request. The transfer will
+        be performed asynchronously.
+      operationId: initiateTransfer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataFlowRequest'
+      responses:
+        "200":
+          description: Data transfer initiated
+        "400":
+          description: Failed to validate request
+  /transfer/{processId}:
+    get:
+      tags:
+      - Data Plane control API
+      description: Get the current state of a data transfer.
+      operationId: getTransferState
+      parameters:
+      - name: processId
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Missing access token
   /transferprocess:
     get:
       tags:
@@ -1669,40 +1896,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
-  /transfer:
-    post:
-      tags:
-      - Data Plane control API
-      description: Initiates a data transfer for the given request. The transfer will
-        be performed asynchronously.
-      operationId: initiateTransfer
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DataFlowRequest'
-      responses:
-        "200":
-          description: Data transfer initiated
-        "400":
-          description: Failed to validate request
-  /transfer/{processId}:
-    get:
-      tags:
-      - Data Plane control API
-      description: Get the current state of a data transfer.
-      operationId: getTransferState
-      parameters:
-      - name: processId
-        in: path
-        required: true
-        style: simple
-        explode: false
-        schema:
-          type: string
-      responses:
-        "200":
-          description: Missing access token
   /{any}:
     get:
       tags:
@@ -1798,17 +1991,7 @@ components:
           type: object
           additionalProperties:
             type: object
-    AssetEntryDto:
-      required:
-      - asset
-      - dataAddress
-      type: object
-      properties:
-        asset:
-          $ref: '#/components/schemas/AssetRequestDto'
-        dataAddress:
-          $ref: '#/components/schemas/DataAddressDto'
-    AssetRequestDto:
+    AssetCreationRequestDto:
       required:
       - properties
       type: object
@@ -1819,6 +2002,16 @@ components:
           type: object
           additionalProperties:
             type: object
+    AssetEntryDto:
+      required:
+      - asset
+      - dataAddress
+      type: object
+      properties:
+        asset:
+          $ref: '#/components/schemas/AssetCreationRequestDto'
+        dataAddress:
+          $ref: '#/components/schemas/DataAddressDto'
     AssetResponseDto:
       type: object
       properties:
@@ -1827,6 +2020,15 @@ components:
           format: int64
         id:
           type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: object
+    AssetUpdateRequestDto:
+      required:
+      - properties
+      type: object
+      properties:
         properties:
           type: object
           additionalProperties:
@@ -1886,7 +2088,7 @@ components:
           $ref: '#/components/schemas/Policy'
         providerAgentId:
           type: string
-    ContractDefinitionRequestDto:
+    ContractDefinitionCreateDto:
       required:
       - accessPolicyId
       - contractPolicyId
@@ -1922,6 +2124,24 @@ components:
             $ref: '#/components/schemas/CriterionDto'
         id:
           type: string
+        validity:
+          type: integer
+          format: int64
+    ContractDefinitionUpdateDto:
+      required:
+      - accessPolicyId
+      - contractPolicyId
+      - criteria
+      type: object
+      properties:
+        accessPolicyId:
+          type: string
+        contractPolicyId:
+          type: string
+        criteria:
+          type: array
+          items:
+            $ref: '#/components/schemas/CriterionDto'
         validity:
           type: integer
           format: int64
@@ -2124,6 +2344,13 @@ components:
           type: string
         uid:
           type: string
+    EntityTag:
+      type: object
+      properties:
+        value:
+          type: string
+        weak:
+          type: boolean
     Failure:
       type: object
       properties:
@@ -2159,6 +2386,61 @@ components:
           format: int64
         id:
           type: string
+    Link:
+      type: object
+      properties:
+        params:
+          type: object
+          additionalProperties:
+            type: string
+        rel:
+          type: string
+        rels:
+          type: array
+          items:
+            type: string
+        title:
+          type: string
+        type:
+          type: string
+        uri:
+          type: string
+          format: uri
+        uriBuilder:
+          $ref: '#/components/schemas/UriBuilder'
+    MediaType:
+      type: object
+      properties:
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        subtype:
+          type: string
+        type:
+          type: string
+        wildcardSubtype:
+          type: boolean
+        wildcardType:
+          type: boolean
+    MultivaluedMapStringObject:
+      type: object
+      properties:
+        empty:
+          type: boolean
+      additionalProperties:
+        type: array
+        items:
+          type: object
+    MultivaluedMapStringString:
+      type: object
+      properties:
+        empty:
+          type: boolean
+      additionalProperties:
+        type: array
+        items:
+          type: string
     NegotiationInitiateRequestDto:
       required:
       - connectorAddress
@@ -2180,6 +2462,38 @@ components:
       properties:
         state:
           type: string
+    NewCookie:
+      type: object
+      properties:
+        comment:
+          type: string
+        domain:
+          type: string
+        expiry:
+          type: string
+          format: date-time
+        httpOnly:
+          type: boolean
+        maxAge:
+          type: integer
+          format: int32
+        name:
+          type: string
+        path:
+          type: string
+        sameSite:
+          type: string
+          enum:
+          - NONE
+          - LAX
+          - STRICT
+        secure:
+          type: boolean
+        value:
+          type: string
+        version:
+          type: integer
+          format: int32
     Permission:
       type: object
       properties:
@@ -2255,6 +2569,13 @@ components:
           type: string
         policy:
           $ref: '#/components/schemas/Policy'
+    PolicyDefinitionUpdateDto:
+      required:
+      - policy
+      type: object
+      properties:
+        policy:
+          $ref: '#/components/schemas/Policy'
     Prohibition:
       type: object
       properties:
@@ -2315,6 +2636,115 @@ components:
           enum:
           - ASC
           - DESC
+    Response:
+      type: object
+      properties:
+        allowedMethods:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+        closed:
+          type: boolean
+        cookies:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/NewCookie'
+        date:
+          type: string
+          format: date-time
+        entity:
+          type: object
+        entityTag:
+          $ref: '#/components/schemas/EntityTag'
+        headers:
+          type: object
+          properties:
+            empty:
+              type: boolean
+          additionalProperties:
+            type: array
+            items:
+              type: object
+        language:
+          type: object
+          properties:
+            country:
+              type: string
+            displayCountry:
+              type: string
+            displayLanguage:
+              type: string
+            displayName:
+              type: string
+            displayScript:
+              type: string
+            displayVariant:
+              type: string
+            extensionKeys:
+              uniqueItems: true
+              type: array
+              items:
+                type: string
+            iso3Country:
+              type: string
+            iso3Language:
+              type: string
+            language:
+              type: string
+            script:
+              type: string
+            unicodeLocaleAttributes:
+              uniqueItems: true
+              type: array
+              items:
+                type: string
+            unicodeLocaleKeys:
+              uniqueItems: true
+              type: array
+              items:
+                type: string
+            variant:
+              type: string
+        lastModified:
+          type: string
+          format: date-time
+        length:
+          type: integer
+          format: int32
+        links:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Link'
+        location:
+          type: string
+          format: uri
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        metadata:
+          type: object
+          properties:
+            empty:
+              type: boolean
+          additionalProperties:
+            type: array
+            items:
+              type: object
+        status:
+          type: integer
+          format: int32
+        statusInfo:
+          $ref: '#/components/schemas/StatusType'
+        stringHeaders:
+          type: object
+          properties:
+            empty:
+              type: boolean
+          additionalProperties:
+            type: array
+            items:
+              type: string
     SelectionRequest:
       type: object
       properties:
@@ -2324,6 +2754,23 @@ components:
           $ref: '#/components/schemas/DataAddress'
         strategy:
           type: string
+    StatusType:
+      type: object
+      properties:
+        family:
+          type: string
+          enum:
+          - INFORMATIONAL
+          - SUCCESSFUL
+          - REDIRECTION
+          - CLIENT_ERROR
+          - SERVER_ERROR
+          - OTHER
+        reasonPhrase:
+          type: string
+        statusCode:
+          type: integer
+          format: int32
     TransferProcessDto:
       type: object
       properties:
@@ -2400,3 +2847,5 @@ components:
           type: string
         isFinite:
           type: boolean
+    UriBuilder:
+      type: object

--- a/resources/openapi/yaml/management-api/policy-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/policy-definition-api.yaml
@@ -170,6 +170,48 @@ paths:
             \ by a contract definition"
       tags:
       - Policy
+  /policydefinitions/{policyId}:
+    put:
+      description: "Updates a policy definition with the given ID if it exists. If\
+        \ a policy definition is not found, no further action is taken\
+        \ DANGER ZONE: Note that updating policy definitions can have unexpected results,\
+        \ do this at your own risk!"
+      operationId: updatePolicy
+      parameters:
+      - in: path
+        name: policyId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyDefinitionUpdateDto'
+      responses:
+        "200":
+          description: Policy definition was updated successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: "Request was malformed, e.g. id was null"
+        "404":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: An policy definition with the given ID does not exist
+      tags:
+      - Policy
     get:
       description: Gets a policy definition with the given ID
       operationId: getPolicy
@@ -381,6 +423,14 @@ components:
         id:
           type: string
           example: null
+        policy:
+          $ref: '#/components/schemas/Policy'
+      required:
+      - policy
+    PolicyDefinitionUpdateDto:
+      type: object
+      example: null
+      properties:
         policy:
           $ref: '#/components/schemas/Policy'
       required:

--- a/resources/openapi/yaml/management-api/policy-definition-api.yaml
+++ b/resources/openapi/yaml/management-api/policy-definition-api.yaml
@@ -170,48 +170,6 @@ paths:
             \ by a contract definition"
       tags:
       - Policy
-  /policydefinitions/{policyId}:
-    put:
-      description: "Updates a policy definition with the given ID if it exists. If\
-        \ a policy definition is not found, no further action is taken\
-        \ DANGER ZONE: Note that updating policy definitions can have unexpected results,\
-        \ do this at your own risk!"
-      operationId: updatePolicy
-      parameters:
-      - in: path
-        name: policyId
-        required: true
-        schema:
-          type: string
-          example: null
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PolicyDefinitionUpdateDto'
-      responses:
-        "200":
-          description: Policy definition was updated successfully
-        "400":
-          content:
-            application/json:
-              schema:
-                type: array
-                example: null
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-          description: "Request was malformed, e.g. id was null"
-        "404":
-          content:
-            application/json:
-              schema:
-                type: array
-                example: null
-                items:
-                  $ref: '#/components/schemas/ApiErrorDetail'
-          description: An policy definition with the given ID does not exist
-      tags:
-      - Policy
     get:
       description: Gets a policy definition with the given ID
       operationId: getPolicy
@@ -247,6 +205,49 @@ paths:
                 items:
                   $ref: '#/components/schemas/ApiErrorDetail'
           description: An  policy definition with the given ID does not exist
+      tags:
+      - Policy
+  /policydefinitions/{policyId}:
+    put:
+      description: "Updates an existing Policy, If the Policy is not found, no further\
+        \ action is taken"
+      operationId: updatePolicy
+      parameters:
+      - in: path
+        name: policyId
+        required: true
+        schema:
+          type: string
+          example: null
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyDefinitionUpdateDto'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+          description: policy definition was updated successfully. Returns the Policy
+            Definition Id and updated timestamp
+        "400":
+          content:
+            application/json:
+              schema:
+                type: array
+                example: null
+                items:
+                  $ref: '#/components/schemas/ApiErrorDetail'
+          description: Request body was malformed
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Response'
+          description: "policy definition could not be updated, because it does not\
+            \ exists"
       tags:
       - Policy
 components:
@@ -333,6 +334,16 @@ components:
         uid:
           type: string
           example: null
+    EntityTag:
+      type: object
+      example: null
+      properties:
+        value:
+          type: string
+          example: null
+        weak:
+          type: boolean
+          example: null
     IdResponseDto:
       type: object
       example: null
@@ -343,6 +354,129 @@ components:
           example: null
         id:
           type: string
+          example: null
+    Link:
+      type: object
+      example: null
+      properties:
+        params:
+          type: object
+          additionalProperties:
+            type: string
+            example: null
+          example: null
+        rel:
+          type: string
+          example: null
+        rels:
+          type: array
+          example: null
+          items:
+            type: string
+            example: null
+        title:
+          type: string
+          example: null
+        type:
+          type: string
+          example: null
+        uri:
+          type: string
+          format: uri
+          example: null
+        uriBuilder:
+          $ref: '#/components/schemas/UriBuilder'
+    MediaType:
+      type: object
+      example: null
+      properties:
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+            example: null
+          example: null
+        subtype:
+          type: string
+          example: null
+        type:
+          type: string
+          example: null
+        wildcardSubtype:
+          type: boolean
+          example: null
+        wildcardType:
+          type: boolean
+          example: null
+    MultivaluedMapStringObject:
+      type: object
+      additionalProperties:
+        type: array
+        example: null
+        items:
+          type: object
+          example: null
+      example: null
+      properties:
+        empty:
+          type: boolean
+          example: null
+    MultivaluedMapStringString:
+      type: object
+      additionalProperties:
+        type: array
+        example: null
+        items:
+          type: string
+          example: null
+      example: null
+      properties:
+        empty:
+          type: boolean
+          example: null
+    NewCookie:
+      type: object
+      example: null
+      properties:
+        comment:
+          type: string
+          example: null
+        domain:
+          type: string
+          example: null
+        expiry:
+          type: string
+          format: date-time
+          example: null
+        httpOnly:
+          type: boolean
+          example: null
+        maxAge:
+          type: integer
+          format: int32
+          example: null
+        name:
+          type: string
+          example: null
+        path:
+          type: string
+          example: null
+        sameSite:
+          type: string
+          enum:
+          - NONE
+          - LAX
+          - STRICT
+          example: null
+        secure:
+          type: boolean
+          example: null
+        value:
+          type: string
+          example: null
+        version:
+          type: integer
+          format: int32
           example: null
     Permission:
       type: object
@@ -427,14 +561,6 @@ components:
           $ref: '#/components/schemas/Policy'
       required:
       - policy
-    PolicyDefinitionUpdateDto:
-      type: object
-      example: null
-      properties:
-        policy:
-          $ref: '#/components/schemas/Policy'
-      required:
-      - policy
     PolicyDefinitionResponseDto:
       type: object
       example: null
@@ -446,6 +572,14 @@ components:
         id:
           type: string
           example: null
+        policy:
+          $ref: '#/components/schemas/Policy'
+      required:
+      - policy
+    PolicyDefinitionUpdateDto:
+      type: object
+      example: null
+      properties:
         policy:
           $ref: '#/components/schemas/Policy'
       required:
@@ -502,3 +636,178 @@ components:
           - ASC
           - DESC
           example: null
+    Response:
+      type: object
+      example: null
+      properties:
+        allowedMethods:
+          type: array
+          example: null
+          items:
+            type: string
+            example: null
+          uniqueItems: true
+        closed:
+          type: boolean
+          example: null
+        cookies:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/NewCookie'
+          example: null
+        date:
+          type: string
+          format: date-time
+          example: null
+        entity:
+          type: object
+          example: null
+        entityTag:
+          $ref: '#/components/schemas/EntityTag'
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            example: null
+            items:
+              type: object
+              example: null
+          example: null
+          properties:
+            empty:
+              type: boolean
+              example: null
+        language:
+          type: object
+          example: null
+          properties:
+            country:
+              type: string
+              example: null
+            displayCountry:
+              type: string
+              example: null
+            displayLanguage:
+              type: string
+              example: null
+            displayName:
+              type: string
+              example: null
+            displayScript:
+              type: string
+              example: null
+            displayVariant:
+              type: string
+              example: null
+            extensionKeys:
+              type: array
+              example: null
+              items:
+                type: string
+                example: null
+              uniqueItems: true
+            iso3Country:
+              type: string
+              example: null
+            iso3Language:
+              type: string
+              example: null
+            language:
+              type: string
+              example: null
+            script:
+              type: string
+              example: null
+            unicodeLocaleAttributes:
+              type: array
+              example: null
+              items:
+                type: string
+                example: null
+              uniqueItems: true
+            unicodeLocaleKeys:
+              type: array
+              example: null
+              items:
+                type: string
+                example: null
+              uniqueItems: true
+            variant:
+              type: string
+              example: null
+        lastModified:
+          type: string
+          format: date-time
+          example: null
+        length:
+          type: integer
+          format: int32
+          example: null
+        links:
+          type: array
+          example: null
+          items:
+            $ref: '#/components/schemas/Link'
+          uniqueItems: true
+        location:
+          type: string
+          format: uri
+          example: null
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        metadata:
+          type: object
+          additionalProperties:
+            type: array
+            example: null
+            items:
+              type: object
+              example: null
+          example: null
+          properties:
+            empty:
+              type: boolean
+              example: null
+        status:
+          type: integer
+          format: int32
+          example: null
+        statusInfo:
+          $ref: '#/components/schemas/StatusType'
+        stringHeaders:
+          type: object
+          additionalProperties:
+            type: array
+            example: null
+            items:
+              type: string
+              example: null
+          example: null
+          properties:
+            empty:
+              type: boolean
+              example: null
+    StatusType:
+      type: object
+      example: null
+      properties:
+        family:
+          type: string
+          enum:
+          - INFORMATIONAL
+          - SUCCESSFUL
+          - REDIRECTION
+          - CLIENT_ERROR
+          - SERVER_ERROR
+          - OTHER
+          example: null
+        reasonPhrase:
+          type: string
+          example: null
+        statusCode:
+          type: integer
+          format: int32
+          example: null
+    UriBuilder:
+      type: object
+      example: null

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2022 T-Systems International GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       T-Systems International GmbH
+ *
+ */
+
+package org.eclipse.edc.spi.event.policydefinition;
+
+/**
+ * Describe a PolicyDefinition deletion, after this has emitted, the PolicyDefinition represented by the id won't be available anymore.
+ */
+public class PolicyDefinitionUpdated extends PolicyDefinitionEvent<PolicyDefinitionUpdated.Payload> {
+
+    private PolicyDefinitionUpdated() {
+    }
+
+    /**
+     * This class contains all event specific attributes of a PolicyDefinition Deletion Event
+     *
+     */
+    public static class Payload extends PolicyDefinitionEvent.Payload {
+    }
+
+    public static class Builder extends PolicyDefinitionEvent.Builder<PolicyDefinitionUpdated, Payload, Builder> {
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        private Builder() {
+            super(new PolicyDefinitionUpdated(), new Payload());
+        }
+    }
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.spi.event.policydefinition;
 
 /**
- * Describe a PolicyDefinition deletion, after this has emitted, the PolicyDefinition represented by the id won't be available anymore.
+ * Describe a PolicyDefinition update, after this has emitted, a PolicyDefinition with a certain id will be available/updated.
  */
 public class PolicyDefinitionUpdated extends PolicyDefinitionEvent<PolicyDefinitionUpdated.Payload> {
 
@@ -23,7 +23,7 @@ public class PolicyDefinitionUpdated extends PolicyDefinitionEvent<PolicyDefinit
     }
 
     /**
-     * This class contains all event specific attributes of a PolicyDefinition Deletion Event
+     * This class contains all event specific attributes of a PolicyDefinition Update Event
      *
      */
     public static class Payload extends PolicyDefinitionEvent.Payload {

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/policydefinition/PolicyDefinitionUpdated.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 T-Systems International GmbH
+ *  Copyright (c) 2023 T-Systems International GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/policydefinition/PolicyDefinitionService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/spi/policydefinition/PolicyDefinitionService.java
@@ -64,4 +64,15 @@ public interface PolicyDefinitionService {
 
     @NotNull
     ServiceResult<PolicyDefinition> create(PolicyDefinition policy);
+
+    /**
+     * Updates a policy. If the policy does not yet exist, {@link ServiceResult#notFound(String)} will be returned.
+     *
+     * @param policyId the ID of the policy to update
+     * @param policy the contents of the policy.
+     *
+     * @return successful if updated, a failure otherwise.
+     */
+    @NotNull
+    ServiceResult<Void> update(String policyId, PolicyDefinition policy);
 }

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/observe/PolicyDefinitionListener.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/observe/PolicyDefinitionListener.java
@@ -42,4 +42,12 @@ public interface PolicyDefinitionListener {
 
     }
 
+    /**
+     * Called after a {@link PolicyDefinition} was updated.
+     *
+     * @param policyDefinition the policyDefinition that has been updated.
+     */
+    default void updated(PolicyDefinition policyDefinition) {
+
+    }
 }

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/policy/spi/store/PolicyDefinitionStore.java
@@ -56,6 +56,15 @@ public interface PolicyDefinitionStore {
     void save(PolicyDefinition policy);
 
     /**
+     * Updates the policy.
+     *
+     * @param policyId ID of the Policy to be updated
+     * @param policy to be updated.
+     * @throws EdcPersistenceException if something goes wrong.
+     */
+    PolicyDefinition update(String policyId, PolicyDefinition policy);
+
+    /**
      * Deletes a policy for the given id.
      *
      * @param policyId id of the policy to be removed.

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -90,6 +90,38 @@ public abstract class PolicyDefinitionStoreTestBase {
                 .extracting(PolicyDefinition::getCreatedAt).isEqualTo(policy2.getCreatedAt());
     }
 
+
+
+    @Test
+    @DisplayName("Update Asset that does not yet exist")
+    void update_policyDoesNotExist() {
+        var id = getRandomId();
+        var policy = getPolicy(id, "target");
+
+        var updated = getPolicyDefinitionStore().update(id, policy);
+        assertThat(updated).isNull();
+    }
+
+    @Test
+    @DisplayName("Update an Asset that exists, adding a property")
+    void update_policyExists() {
+        var id = getRandomId();
+        var policy = getPolicy(id, "target");
+
+        getPolicyDefinitionStore().save(policy);
+
+        var newPolicy = createPolicy(id, "target2");
+        var result = getPolicyDefinitionStore().update(id, newPolicy);
+
+        var spec = QuerySpec.Builder.newInstance().build();
+        var policyFromDb = getPolicyDefinitionStore().findAll(spec);
+
+        Assertions.assertThat(policyFromDb).hasSize(1).first();
+        assertThat(result).isNotNull();
+        assertThat(result.getPolicy().getTarget()).isEqualTo("target2");
+        assertThat(result).isNotNull().usingRecursiveComparison().isEqualTo(newPolicy);
+    }
+
     @Test
     @DisplayName("Find policy by ID that exists")
     void findById_whenPresent() {
@@ -534,4 +566,15 @@ public abstract class PolicyDefinitionStoreTestBase {
     private String getRandomId() {
         return UUID.randomUUID().toString();
     }
+
+
+    private static PolicyDefinition getPolicy(String id, String target) {
+        return PolicyDefinition.Builder.newInstance()
+                .policy(Policy.Builder.newInstance()
+                        .target(target)
+                        .build())
+                .id(id)
+                .build();
+    }
+
 }

--- a/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
+++ b/spi/control-plane/policy-spi/src/testFixtures/java/org/eclipse/edc/connector/policy/spi/testfixtures/store/PolicyDefinitionStoreTestBase.java
@@ -93,7 +93,7 @@ public abstract class PolicyDefinitionStoreTestBase {
 
 
     @Test
-    @DisplayName("Update Asset that does not yet exist")
+    @DisplayName("Update Policy that does not yet exist")
     void update_policyDoesNotExist() {
         var id = getRandomId();
         var policy = getPolicy(id, "target");
@@ -103,7 +103,7 @@ public abstract class PolicyDefinitionStoreTestBase {
     }
 
     @Test
-    @DisplayName("Update an Asset that exists, adding a property")
+    @DisplayName("Update an Policy that exists, adding a property")
     void update_policyExists() {
         var id = getRandomId();
         var policy = getPolicy(id, "target");


### PR DESCRIPTION
## What this PR changes/adds

Adds the UPDATE endpoint to the PolicyDefinitionApi:

- adds one PUT endpoint to the PolicyDefinitionApiController
- adds new update() method to the PolicyDefinitionStore
- adds implementations for CosmosPolicyDefinitionStore, InMemoryPolicyDefinitionStore, SqlPolicyDefinitionStore
- adds tests for all the implementations

## Why it does that

To enable update semantics on PolicyDefinition.

## Further notes

- Created PolicyDefinitionUpdateDto, to exclude the ID. The policyId is passed as path param.
- Created PolicyDefinitionDto as a Parent Dto for PolicyDefinitionUpdateDto and PolicyDefinitionUpdateDto
- Updating Policy will fail if the Policy isn't found.

## Linked Issue(s)

Closes #2509

## Checklist

- [x] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
