### PR TITLE
Vault with GCP Secret Manager - first implementation

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -43,6 +43,7 @@
     - Vault
         - [Azure](common/vault/vault-azure/)
         - [Filesystem](common/vault/vault-filesystem/)
+        - [GCP](common/vault/vault-gcp/)
         - [HashiCorp](common/vault/vault-hashicorp/)
 - Control Plane
     - [Management API](control-plane/api/management-api/)

--- a/extensions/common/vault/vault-gcp/README.md
+++ b/extensions/common/vault/vault-gcp/README.md
@@ -1,0 +1,15 @@
+# GCP Secret Manager Vault
+
+The vault-gcp extension is an implementation of the Vault interface based on GCP Secret Manager.
+Arbitrary key names are possible through the key sanitation feature. 
+
+## Settingss
+
+- edc.vault.gcp.project : optional setting to specify the GCP project hosting the Secret Manager API. If not specified, the default project is used ( see ServiceOptions.getDefaultProjectId() )
+- edc.vault.gcp.saccount_file : optional setting providing the path to a service account (JSON) file, to be used for credentials. If not specified, default credentials are used (not recommended)
+- edc.vault.gcp.region : mandatory setting to specify secret replica location
+
+## Decisions
+- Secrets will not be overwritten if they exist to prevent potential leakage of credentials to third parties.
+- Keys strings are sanitized to comply with key requirements of AWS Secrets Manager. Sanitizing replaces all illegal characters with '-' and appends the hash code of the original key to minimize the risk of key collision after the transformation, because the replacement operation is a many-to-one function. A warning will be logged if the key contains illegal characters.
+

--- a/extensions/common/vault/vault-gcp/build.gradle.kts
+++ b/extensions/common/vault/vault-gcp/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":core:common:util"))
+
+    implementation(platform("com.google.cloud:libraries-bom:26.1.4"))
+
+    implementation(libs.googlecloud.iam.admin)
+    implementation(libs.googlecloud.iam.credentials)
+    implementation("com.google.cloud:google-cloud-core")
+    implementation("com.google.cloud:google-cloud-secretmanager")
+    implementation("com.google.api:gax-grpc")
+    implementation("com.google.auth:google-auth-library-oauth2-http")
+    testImplementation(project(":core:common:junit"))
+}

--- a/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVault.java
+++ b/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVault.java
@@ -1,0 +1,241 @@
+/*
+ *  Copyright (c) 2022 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.vault.gcp;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.AlreadyExistsException;
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.cloud.secretmanager.v1.SecretVersion;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import com.google.protobuf.ByteString;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Vault extension implemented with GCP Secret Manager
+ */
+public class GcpSecretManagerVault implements Vault {
+
+    private final Monitor monitor;
+    private final String project;
+    private final String region;
+    private final SecretManagerServiceClient secretManagerServiceClient;
+
+    private static final String LATEST_VERSION_ALIAS = "latest"; // alias for the latest version of a Secret
+    private static final int MAX_KEY_LENGTH = 255; // maximum Secret Manager key length
+    private static final int HASH_LENGTH = 8; // Object.hashCode() returns int, which is 32 bit, in hex results in 8 char
+
+    /**
+     * Factory helper constructing Vault object with default GCP credentials
+     *
+     * @param monitor monitor object for logging
+     * @param project GCP project name
+     * @param region replica location for secrects created by the vault
+     * @return the created Vault object backed by Secret Manager
+     */
+    public static GcpSecretManagerVault createWithDefaultSettings(Monitor monitor, String project, String region) throws IOException {
+        return new GcpSecretManagerVault(monitor, project, region, SecretManagerServiceClient.create());
+    }
+
+    /**
+     * Factory helper constructing Vault object with service account GCP credentials
+     *
+     * @param monitor monitor object for logging
+     * @param project GCP project name
+     * @param region replica location for secrects created by the vault
+     * @param filePath path of the JSON file with service account credentials
+     * @return the created Vault object backed by Secret Manager
+     */
+    public static GcpSecretManagerVault createWithServiceAccountCredentials(Monitor monitor, String project, String region, String filePath) throws IOException {
+        // TODO add proxy support
+        var serviceAccountCredentials = ServiceAccountCredentials.fromStream(new FileInputStream(filePath));
+        var settings = SecretManagerServiceSettings.newBuilder()
+                    .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentials))
+                    .build();
+       return new GcpSecretManagerVault(monitor, project, region, SecretManagerServiceClient.create(settings));
+    }
+
+    /**
+     * Vault object constructor
+     *
+     * @param monitor monitor object for logging
+     * @param project GCP project name
+     * @param region replica location for secrects created by the vault
+     * @param secretClient GCP client to Secret Manager service (already authenticated)
+     * @return the created Vault object backed by Secret Manager
+     */
+    public GcpSecretManagerVault(Monitor monitor, String project, String region, SecretManagerServiceClient secretClient) {
+        this.monitor = monitor;
+        this.project = project;
+        this.region = region;
+        this.secretManagerServiceClient = secretClient;
+    }
+
+    /**
+     * Retrieves the secret stored under a specific key
+     *
+     * @param key string key identifying the secret to be fetched
+     * @return the string if the secret is found, null otherwise
+     */
+    @Override
+    public @Nullable String resolveSecret(String key) {
+        try {
+            key = sanitizeKey(key);
+            SecretVersionName secretVersionName = SecretVersionName.of(project, key, LATEST_VERSION_ALIAS);
+            AccessSecretVersionResponse response = secretManagerServiceClient.accessSecretVersion(secretVersionName);
+            String payload = response.getPayload().getData().toStringUtf8();
+            return payload;
+        } catch (NotFoundException nfex) {
+            monitor.debug("Secret not found or has no version: " + key);
+            return null;
+        } catch (RuntimeException rex) {
+            monitor.severe("Runtime error while resolving secret " + key + ": " + rex.getMessage(), rex);
+            return null;
+        } catch (Exception ex) {
+            monitor.debug("Exception while resolving secret " + key + ": " + ex.getMessage(), ex);
+            return null;
+        }
+    }
+
+    /**
+     * Saves a secret stored under a specific key. If the selected key is already in use by a secrect, error is returned and existing secret not overwritten
+     *
+     * @param key string key identifying the secret to be stored
+     * @param value string value of the secret
+     * @return Result.success if the secret is stored
+     */
+    @Override
+    public Result<Void> storeSecret(String key, String value) {
+        try {
+            key = sanitizeKey(key);
+            Secret secret =
+                    Secret.newBuilder()
+                    .setReplication(
+                        Replication.newBuilder()
+                        .setUserManaged(Replication.UserManaged.newBuilder()
+                            // TODO add multi-region replica support?
+                            .addReplicas(Replication.UserManaged.Replica.newBuilder()
+                                .setLocation(region)
+                                .build())
+                            .build())
+                        .build())
+                    .build();
+
+            ProjectName parent = ProjectName.of(project);
+            Secret createdSecret = secretManagerServiceClient.createSecret(parent, key, secret);
+
+            SecretPayload payload =
+                    SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(value)).build();
+            SecretVersion addedVersion = secretManagerServiceClient.addSecretVersion(createdSecret.getName(), payload);
+            return Result.success();
+        } catch (AlreadyExistsException aeex) {
+            monitor.debug("Secret already exists " + key);
+            return Result.failure("Secret already exists " + key);
+        } catch (NotFoundException nfex) {
+            monitor.debug("Secret not found or has no version: " + key);
+            return Result.failure("Secret not found or has no version: " + key);
+        } catch (RuntimeException rex) {
+            monitor.severe("Runtime error while storing secret " + key + ": " + rex.getMessage(), rex);
+            return Result.failure(rex.getMessage());
+        } catch (Exception ex) {
+            monitor.debug("Exception while storing secret " + key + ": " + ex.getMessage(), ex);
+            return Result.failure(ex.getMessage());
+        }
+    }
+
+    /**
+     * Deletes a secret stored under a specific key. If the selected key is not in use, error is returned
+     *
+     * @param key string key identifying the secret to be deleted
+     * @return Result.success if the secret is deleted
+     */
+    @Override
+    public Result<Void> deleteSecret(String key) {
+        try {
+            key = sanitizeKey(key);
+            SecretName name = SecretName.of(project, key);
+            secretManagerServiceClient.deleteSecret(name);
+            return Result.success();
+        } catch (NotFoundException nfex) {
+            monitor.debug("Secret not found or has no version: " + key);
+            return Result.failure("Secret not found or has no version: " + key);
+        } catch (RuntimeException rex) {
+            monitor.severe("Runtime error while deleting secret " + key + ": " + rex.getMessage(), rex);
+            return Result.failure(rex.getMessage());
+        } catch (Exception ex) {
+            monitor.debug("Exception while deleting secret " + key + ": " + ex.getMessage(), ex);
+            return Result.failure(ex.getMessage());
+        }
+    }
+
+    /**
+     * Checks if the given key parameter fits GCP requirements, if not it will:
+     * - any invalid character is replaced with dash '-' char
+     * - if the key is too long it is truncated to max 255 chars
+     * -  if the key is changed in the process, original key is hashed into a 8-chars string appended at the end of the returned key
+     *
+     * Secret key is a string with a maximum length of 255 characters and can contain uppercase and lowercase letters, digits, and the hyphen (`-`) and underscore (`_`) characters.
+     *
+     * @param key string key to be checked and sanitized
+     * @return sanitized key
+     */
+    String sanitizeKey(String key) {
+        boolean modified = false;
+        var originalKey = key;
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < key.length(); i++) {
+            var c = key.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_' && c != '-') {
+                modified = true;
+                sb.append('-');
+            } else {
+                sb.append(c);
+            }
+
+            if (sb.length() > MAX_KEY_LENGTH ||
+                    (modified && sb.length() > (MAX_KEY_LENGTH - HASH_LENGTH - 1))) {
+                sb.setLength(MAX_KEY_LENGTH - HASH_LENGTH - 1);
+                modified = true;
+                i = key.length();
+            }
+        }
+
+        if (modified) {
+            var originalKeyHash = String.format("%08X", originalKey.hashCode());
+            var fixedKey = sb.append('_').append(originalKeyHash).toString();
+            monitor.warning("GCP Secret Manager vault sanitized the key, original:" + originalKey + " fixed:" + fixedKey);
+            return fixedKey;
+        }
+
+        // key do not need sanitization
+        return key;
+    }
+}
+

--- a/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtension.java
+++ b/extensions/common/vault/vault-gcp/src/main/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtension.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2022 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.vault.gcp;
+
+import com.google.cloud.ServiceOptions;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.security.CertificateResolver;
+import org.eclipse.edc.spi.security.PrivateKeyResolver;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.security.VaultCertificateResolver;
+import org.eclipse.edc.spi.security.VaultPrivateKeyResolver;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.io.IOException;
+
+import static org.eclipse.edc.util.configuration.ConfigurationFunctions.propOrEnv;
+import static org.eclipse.edc.util.string.StringUtils.isNullOrEmpty;
+
+/**
+ * ServiceExtension instantiating and registering Vault object
+ */
+@Provides({ Vault.class, PrivateKeyResolver.class, CertificateResolver.class })
+@Extension(value = GcpSecretManagerVaultExtension.NAME)
+public class GcpSecretManagerVaultExtension implements ServiceExtension {
+
+    public static final String NAME = "GCP Secret Manager";
+
+    @Setting(value = "GCP Project for Vault", required = false)
+    static final String VAULT_PROJECT = "edc.vault.gcp.project";
+
+    @Setting(value = "JSON file with Service Account credentials", required = false)
+    static final String VAULT_SACCOUNT_FILE = "edc.vault.gcp.saccount_file";
+
+    @Setting(value = "GCP Region for Vault Secret replication", required = true)
+    static final String VAULT_REGION = "edc.vault.gcp.region";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        String project = context.getSetting(VAULT_PROJECT, null);
+        if (isNullOrEmpty(project)) {
+            project = ServiceOptions.getDefaultProjectId();
+            context.getMonitor().info("GCP Secret Manager vault extension: project loaded from default config " + project);
+        } else {
+            context.getMonitor().info("GCP Secret Manager vault extension: project loaded from settings " + project);
+        }
+
+        String saccountFile = context.getSetting(VAULT_SACCOUNT_FILE, null);
+
+        // TODO support multi-region replica
+        String region = getMandatorySetting(context, VAULT_REGION);
+        context.getMonitor().info("GCP Secret Manager vault extension: region selected " + region);
+        try {
+            GcpSecretManagerVault vault = null;
+            if (saccountFile == null) {
+                context.getMonitor().info("Creating GCP Secret Manager vault extension with default access settings");
+                vault = GcpSecretManagerVault.createWithDefaultSettings(context.getMonitor(), project, region);
+            } else {
+                context.getMonitor().info("Creating GCP Secret Manager vault extension with Service Account credentials from file " + saccountFile);
+                vault = GcpSecretManagerVault.createWithServiceAccountCredentials(context.getMonitor(), project, region, saccountFile);
+            }
+            context.registerService(Vault.class, vault);
+            context.registerService(PrivateKeyResolver.class, new VaultPrivateKeyResolver(vault));
+            context.registerService(CertificateResolver.class, new VaultCertificateResolver(vault));
+        } catch (IOException ioex) {
+            throw new EdcException("cannot create vault " + ioex);
+        }
+    }
+
+    // TODO implement a common implementation in org.eclipse.edc.spi.system.ServiceExtension to be shared?
+    private String getMandatorySetting(ServiceExtensionContext context, String setting) {
+        var value = context.getSetting(setting, null);
+        if (isNullOrEmpty(value)) {
+            value = propOrEnv(setting, null);
+            if (isNullOrEmpty(value)) {
+                throw new EdcException("setting '" + setting + "' is not provided");
+            }
+        }
+        return value;
+    }
+}

--- a/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtensionTest.java
+++ b/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultExtensionTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2022 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.vault.gcp;
+
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+class GcpSecretManagerVaultExtensionTest {
+
+    private final Monitor monitor = mock(Monitor.class);
+    private final GcpSecretManagerVaultExtension extension = new GcpSecretManagerVaultExtension();
+
+    private static final String TEST_REGION = "europe-west3";
+    private static final String TEST_PROJECT = "project";
+
+    @BeforeEach
+    void resetMocks() {
+        reset(monitor);
+    }
+
+    @Test
+    void noSettings_shouldThrowException() {
+        ServiceExtensionContext invalidContext = mock(ServiceExtensionContext.class);
+        when(invalidContext.getMonitor()).thenReturn(monitor);
+
+        Assertions.assertThrows(EdcException.class, () -> extension.initialize(invalidContext));
+    }
+
+    @Test
+    void onlyProjectSetting_shouldThrowException() {
+        ServiceExtensionContext invalidContext = mock(ServiceExtensionContext.class);
+        when(invalidContext.getMonitor()).thenReturn(monitor);
+        when(invalidContext.getSetting(GcpSecretManagerVaultExtension.VAULT_PROJECT, null)).thenReturn(TEST_PROJECT);
+
+        Assertions.assertThrows(EdcException.class, () -> extension.initialize(invalidContext));
+    }
+
+    @Test
+    void onlyRegionSetting_shouldNotThrowException() {
+        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
+        when(validContext.getMonitor()).thenReturn(monitor);
+        when(validContext.getSetting(GcpSecretManagerVaultExtension.VAULT_REGION, null)).thenReturn(TEST_REGION);
+
+        extension.initialize(validContext);
+    }
+
+    @Test
+    void mandatorySettings_shouldNotThrowException() {
+        ServiceExtensionContext validContext = mock(ServiceExtensionContext.class);
+        when(validContext.getMonitor()).thenReturn(monitor);
+        when(validContext.getSetting(GcpSecretManagerVaultExtension.VAULT_PROJECT, null)).thenReturn(TEST_PROJECT);
+        when(validContext.getSetting(GcpSecretManagerVaultExtension.VAULT_REGION, null)).thenReturn(TEST_REGION);
+
+        extension.initialize(validContext);
+    }
+}

--- a/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultTest.java
+++ b/extensions/common/vault/vault-gcp/src/test/java/org/eclipse/edc/vault/gcp/GcpSecretManagerVaultTest.java
@@ -1,0 +1,277 @@
+/*
+ *  Copyright (c) 2022 Google LLC
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Google LCC - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.vault.gcp;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.api.gax.rpc.StatusCode;
+
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.ProjectName;
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretName;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.ArgumentMatchers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.TestInstance.Lifecycle;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.UUID;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class GcpSecretManagerVaultTest {
+
+    class TestStatusCode implements StatusCode {
+        @Override
+        public Integer getTransportCode() {
+            return new Integer(0);
+        }
+
+        @Override
+        public Code getCode() {
+            return Code.OK;
+        }
+    }
+
+    private static final String TEST_REGION = "europe-west3";
+    private static final String TEST_PROJECT = "project";
+    private static final String VALID_KEY = "test";
+    private static final String INVALID_KEY = "test=";
+    private static final String SANITIZED_KEY = "test-_06924DEB";
+
+    private static final int MAX_KEY_LENGTH = 255;
+
+    private final Monitor monitor = mock(Monitor.class);
+    private final SecretManagerServiceClient secretClient = mock(SecretManagerServiceClient.class);
+    private final GcpSecretManagerVault vault = new GcpSecretManagerVault(monitor, TEST_PROJECT, TEST_REGION, secretClient);
+    private final Secret testSecret =
+                    Secret.newBuilder()
+                    .setReplication(
+                        Replication.newBuilder()
+                        .setUserManaged(Replication.UserManaged.newBuilder()
+                            .addReplicas(Replication.UserManaged.Replica.newBuilder()
+                                .setLocation(TEST_REGION)
+                                .build())
+                            .build())
+                        .build())
+                    .build();
+
+    private ArrayList<Character> validChars = new ArrayList<Character>();
+    private ArrayList<Character> invalidChars = new ArrayList<Character>();
+    private Random randGen = new Random();
+
+    private boolean isValidKey(String key) {
+        if (key.length() > MAX_KEY_LENGTH)
+            return false;
+
+        for (int i = 0; i < key.length(); i++) {
+            var c = key.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_' && c != '-')
+                return false;
+        }
+
+        return true;
+    }
+
+    private char getRandomValidChar() {
+        return validChars.get(randGen.nextInt(validChars.size()));
+    }
+
+    private char getRandomInvalidChar() {
+        return invalidChars.get(randGen.nextInt(invalidChars.size()));
+    }
+
+    private String getRandomKeyWithValidChars(int length) {
+        var sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            var c = getRandomValidChar();
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private String getRandomKeyWithInvalidChars(int length, int errors) {
+        String key = getRandomKeyWithValidChars(length);
+        StringBuilder keyBuilder = new StringBuilder(key);
+        ArrayList<Integer> positions = new ArrayList<Integer>();
+        for (int i=0; i<length; i++) {
+            positions.add(i);
+        }
+
+        for (int i=0; i<errors && positions.size() > 0; i++) {
+            int index = randGen.nextInt(positions.size());
+            int position = positions.get(index);
+            positions.remove(index);
+
+            keyBuilder.setCharAt(position, getRandomInvalidChar());
+        }
+
+        return keyBuilder.toString();
+    }
+
+    @BeforeAll
+    void init() {
+        // Init the array with the chars allowed and not allowed in a Secret Key.
+        // Secret key is a string with a maximum length of 255 characters and can
+        // contain uppercase and lowercase letters, digits, and the hyphen (`-`) and
+        // underscore (`_`) characters.
+        for (char c='a'; c<='z'; c++) {
+            validChars.add(c);
+        }
+        for (char c='A'; c<='Z'; c++) {
+            validChars.add(c);
+        }
+        for (char c='0'; c<='9'; c++) {
+            validChars.add(c);
+        }
+        validChars.add('-');
+        validChars.add('_');
+
+        for (char c=32; c<=126; c++) {
+            if (!Character.isLetterOrDigit(c) && c != '_' && c != '-') {
+                invalidChars.add(c);
+            }
+        }
+
+        randGen.setSeed(System.currentTimeMillis());
+    }
+
+    @BeforeEach
+    void resetMocks() {
+        reset(monitor, secretClient);
+    }
+
+    @Test
+    void storeSecret_shallSanitizeKey() {
+        ProjectName parent = ProjectName.of(TEST_PROJECT);
+        when(secretClient.createSecret(parent, SANITIZED_KEY, testSecret))
+                .thenReturn(testSecret);
+
+        var randomContent = UUID.randomUUID().toString();
+        vault.storeSecret(INVALID_KEY, randomContent);
+        verify(secretClient).createSecret(parent, SANITIZED_KEY, testSecret);
+    }
+
+    @Test
+    void resolveSecret_shallSanitizeKey() {
+        vault.resolveSecret(INVALID_KEY);
+
+        SecretVersionName secretVersionName = SecretVersionName.of(TEST_PROJECT, SANITIZED_KEY, "latest");
+        verify(secretClient).accessSecretVersion(secretVersionName);
+    }
+
+    @Test
+    void deleteSecret_shallSanitizeKey() {
+        vault.deleteSecret(INVALID_KEY);
+
+        verify(secretClient).deleteSecret(SecretName.of(TEST_PROJECT, SANITIZED_KEY));
+    }
+
+    @Test
+    void sanitizeKey_testValidKeys() {
+        for (int i=0; i<100; i++) {
+            int len = 1 + randGen.nextInt(MAX_KEY_LENGTH);
+            String validKey = getRandomKeyWithValidChars(len);
+            String sanitizedKey = vault.sanitizeKey(validKey);
+            assertTrue(validKey.equals(sanitizedKey));
+            assertTrue(isValidKey(sanitizedKey));
+        }
+    }
+
+    @Test
+    void sanitizeKey_testLongKeyWithValidCharKey() {
+        for (int i=0; i<100; i++) {
+            int len = MAX_KEY_LENGTH + 1 + randGen.nextInt(MAX_KEY_LENGTH);
+            String longKey = getRandomKeyWithValidChars(len);
+            String sanitizedKey = vault.sanitizeKey(longKey);
+            assertFalse(isValidKey(longKey));
+            assertTrue(isValidKey(sanitizedKey));
+        }
+    }
+
+    @Test
+    void sanitizeKey_testLongKeyWithInvalidCharKey() {
+        for (int i=0; i<100; i++) {
+            int len = MAX_KEY_LENGTH + 1 + randGen.nextInt(MAX_KEY_LENGTH);
+            int invCharCount = 1 + randGen.nextInt(len);
+            String longInvalidKey = getRandomKeyWithInvalidChars(len, invCharCount);
+            String sanitizedKey = vault.sanitizeKey(longInvalidKey);
+            assertFalse(isValidKey(longInvalidKey));
+            assertTrue(isValidKey(sanitizedKey));
+        }
+    }
+
+    @Test
+    void sanitizeKey_longKeysDifferingAfter255CharsStillDifferent() {
+        for (int i=0; i<100; i++) {
+            int len = MAX_KEY_LENGTH + 1 + randGen.nextInt(MAX_KEY_LENGTH);
+            String longKey = getRandomKeyWithValidChars(len);
+            int extraLen = len - MAX_KEY_LENGTH;
+            int diffPosition = MAX_KEY_LENGTH + randGen.nextInt(extraLen);
+            StringBuilder sb = new StringBuilder(longKey);
+            char c = sb.charAt(diffPosition);
+            do {
+                c = (char)(c+1);
+            } while (!validChars.contains(c));
+
+            sb.setCharAt(diffPosition, (char)(c+1));
+            String longDiffKey = sb.toString();
+
+            String sanitizedKey = vault.sanitizeKey(longKey);
+            String sanitizedDiffKey = vault.sanitizeKey(longDiffKey);
+            assertFalse(sanitizedKey.equals(sanitizedDiffKey));
+            assertTrue(isValidKey(sanitizedKey));
+            assertTrue(isValidKey(sanitizedDiffKey));
+        }
+    }
+
+    @Test
+    void resolveSecret_shallReturnNullAndLogDebugIfSecretNotFound() {
+        var status = new TestStatusCode();
+        when(secretClient.accessSecretVersion(ArgumentMatchers.isA(SecretVersionName.class)))
+                .thenThrow(new NotFoundException("test", new Exception("test"), status, false));
+        var result = vault.resolveSecret(VALID_KEY);
+
+        assertThat(result).isNull();
+        verify(monitor).debug(ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void resolveSecret_shallReturnNullAndLogSevereOnGenericException() {
+        when(secretClient.accessSecretVersion(ArgumentMatchers.isA(SecretVersionName.class)))
+                .thenThrow(new RuntimeException("test"));
+
+        var result = vault.resolveSecret(VALID_KEY);
+
+        assertThat(result).isNull();
+        verify(monitor).severe(ArgumentMatchers.anyString(), ArgumentMatchers.isA(RuntimeException.class));
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -118,6 +118,7 @@ include(":extensions:common:transaction:transaction-local")
 include(":extensions:common:vault:vault-aws")
 include(":extensions:common:vault:vault-azure")
 include(":extensions:common:vault:vault-filesystem")
+include(":extensions:common:vault:vault-gcp")
 include(":extensions:common:vault:vault-hashicorp")
 
 include(":extensions:common:api:control-api-configuration")


### PR DESCRIPTION
## Vault with GCP Secret Manager - first implementation

The PR includes the first implementation of EDC Vault using GCP Secret Manager

- [X ] added appropriate tests?
- [X] performed checkstyle check locally?
- [X] added/updated copyright headers?
- [X] documented public classes/methods?
- [X] added/updated relevant documentation?
- [X] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [X] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
